### PR TITLE
docs: add theme transition TODO and update roadmap for #25

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -9,7 +9,8 @@ import rehypeRaw from 'rehype-raw';
 import rehypeHighlight from 'rehype-highlight';
 import { githubLight } from '@fsegurai/codemirror-theme-github-light'; // When dark theme is set up change with @fsegurai/codemirror-theme-github-dark
 import 'highlight.js/styles/github.css';
-import 'github-markdown-css/github-markdown-light.css';
+import 'github-markdown-css/github-markdown-light.css'; // TODO: remove light theme and leave ordinary one, for supporting both themes.
+// Reference: https://github.com/sindresorhus/github-markdown-css
 import { useAppContext } from '../../contexts/AppProvider.tsx';
 import EditorMode from './EditorMode.tsx';
 import { EditorModeEnum } from '../../types/editor/editorEnums.ts';


### PR DESCRIPTION
Updated comment regarding the light theme for markdown CSS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified theme handling in the editor by adding a TODO next to the `github-markdown-css/github-markdown-light.css` import and a reference link. This documents the plan to remove the light-only style when dark mode lands (issue #25).

<sup>Written for commit c78976c9432c33839a5e4189c9c900cfcbfeb70b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

