### PR TITLE
47 add delete buttons to files

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -154,6 +154,26 @@ fn load_files(app: AppHandle) -> Result<Vec<FileInfo>, String> {
     Ok(files)
 }
 
+#[tauri::command]
+fn delete_file(app: AppHandle, file_name: String) -> Result<(), String> {
+    use std::fs;
+
+    let app_dir = app
+        .path()
+        .app_data_dir()
+        .expect("failed to retrieve app data dir");
+
+    let file_path = app_dir.join(file_name + ".md");
+
+    if file_path.exists() {
+        fs::remove_file(&file_path)
+            .map_err(|e| format!("Failed to delete file: {}", e))?;
+        Ok(())
+    } else {
+        Err("File not found".to_string())
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -165,7 +185,8 @@ pub fn run() {
             add_file,
             load_files,
             load_content_by_name,
-            save_content_by_name
+            save_content_by_name,
+            delete_file
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,7 +155,7 @@ fn load_files(app: AppHandle) -> Result<Vec<FileInfo>, String> {
 }
 
 #[tauri::command]
-fn delete_file(app: AppHandle, file_name: String) -> Result<(), String> {
+fn delete_file_by_name(app: AppHandle, file_name: String) -> Result<(), String> {
     use std::fs;
 
     let app_dir = app
@@ -186,7 +186,7 @@ pub fn run() {
             load_files,
             load_content_by_name,
             save_content_by_name,
-            delete_file
+            delete_file_by_name
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lumark",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "identifier": "com.albertarakelyan.lumark",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/src/components/Layouts/MainLayout/FilesPanel/FileItem.tsx
+++ b/src/components/Layouts/MainLayout/FilesPanel/FileItem.tsx
@@ -15,6 +15,8 @@ const FileItem: FC<IFileItemProps> = ({ file }) => {
   };
 
   const handleDeleteClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation(); // Prevent the click event from bubbling up to the file item
+
     // TODO: Replace the window.confirm with a custom modal for better UX
     const shouldDelete = window.confirm(`Are you sure you want to delete the file "${file.file_name}"? This action cannot be undone.`);
 
@@ -22,7 +24,6 @@ const FileItem: FC<IFileItemProps> = ({ file }) => {
       return;
     }
 
-    e.stopPropagation(); // Prevent the click event from bubbling up to the file item
     console.log(`Delete clicked for file: ${file.file_name}`);
     // Call the delete function from context here, e.g., deleteFile(file.file_name);
     deleteFile(file.file_name);

--- a/src/components/Layouts/MainLayout/FilesPanel/FileItem.tsx
+++ b/src/components/Layouts/MainLayout/FilesPanel/FileItem.tsx
@@ -3,13 +3,13 @@ import { IFileItemProps } from './types';
 import { useAppContext } from '../../../../contexts/AppProvider';
 
 const FileItem: FC<IFileItemProps> = ({ file }) => {
-  const { handleFileSelect, selectedFile } = useAppContext();
+  const { selectFile, selectedFile } = useAppContext();
 
   const epoch = Number(file.date_created);
 
   const handleFileClick = (fileName: string) => {
     console.log(`File clicked: ${fileName}`);
-    handleFileSelect(fileName);
+    selectFile(fileName);
   };
 
   return (

--- a/src/components/Layouts/MainLayout/FilesPanel/FileItem.tsx
+++ b/src/components/Layouts/MainLayout/FilesPanel/FileItem.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+import { IFileItemProps } from './types';
+import { useAppContext } from '../../../../contexts/AppProvider';
+
+const FileItem: FC<IFileItemProps> = ({ file }) => {
+  const { handleFileSelect, selectedFile } = useAppContext();
+
+  const epoch = Number(file.date_created);
+
+  const handleFileClick = (fileName: string) => {
+    console.log(`File clicked: ${fileName}`);
+    handleFileSelect(fileName);
+  };
+
+  return (
+    <div
+      key={file.file_name}
+      className={`flex flex-col gap-y-0.5 p-2 hover:bg-gray-bg-hover cursor-pointer rounded-xl relative after:absolute after:bottom-0 after:left-0 after:w-full after:h-px after:bg-border-color/50 after:content-[''] ${file.file_name === selectedFile ? 'bg-gray-bg-active' : ''}`}
+      onClick={() => handleFileClick(file.file_name)}
+    >
+      <h3 className="font-medium">{file.file_name}</h3>
+      <p className="text-sm text-muted-text">
+            Created: <span>{new Date(epoch * 1000).toLocaleDateString()}</span>
+      </p>
+    </div>
+  );
+};
+
+export default FileItem;

--- a/src/components/Layouts/MainLayout/FilesPanel/FileItem.tsx
+++ b/src/components/Layouts/MainLayout/FilesPanel/FileItem.tsx
@@ -1,9 +1,11 @@
 import { FC } from 'react';
+import { Trash2Icon } from 'lucide-react';
 import { IFileItemProps } from './types';
 import { useAppContext } from '../../../../contexts/AppProvider';
+import Button from '../../../UI/Button/Button';
 
 const FileItem: FC<IFileItemProps> = ({ file }) => {
-  const { selectFile, selectedFile } = useAppContext();
+  const { selectFile, selectedFile, deleteFile } = useAppContext();
 
   const epoch = Number(file.date_created);
 
@@ -12,16 +14,37 @@ const FileItem: FC<IFileItemProps> = ({ file }) => {
     selectFile(fileName);
   };
 
+  const handleDeleteClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    // TODO: Replace the window.confirm with a custom modal for better UX
+    const shouldDelete = window.confirm(`Are you sure you want to delete the file "${file.file_name}"? This action cannot be undone.`);
+
+    if (!shouldDelete) {
+      return;
+    }
+
+    e.stopPropagation(); // Prevent the click event from bubbling up to the file item
+    console.log(`Delete clicked for file: ${file.file_name}`);
+    // Call the delete function from context here, e.g., deleteFile(file.file_name);
+    deleteFile(file.file_name);
+  };
+
   return (
     <div
       key={file.file_name}
-      className={`flex flex-col gap-y-0.5 p-2 hover:bg-gray-bg-hover cursor-pointer rounded-xl relative after:absolute after:bottom-0 after:left-0 after:w-full after:h-px after:bg-border-color/50 after:content-[''] ${file.file_name === selectedFile ? 'bg-gray-bg-active' : ''}`}
+      className={`group flex flex-col gap-y-0.5 p-2 hover:bg-gray-bg-hover cursor-pointer rounded-xl relative after:absolute after:bottom-0 after:left-0 after:w-full after:h-px after:bg-border-color/50 after:content-[''] ${file.file_name === selectedFile ? 'bg-gray-bg-active' : ''}`}
       onClick={() => handleFileClick(file.file_name)}
     >
       <h3 className="font-medium">{file.file_name}</h3>
       <p className="text-sm text-muted-text">
-            Created: <span>{new Date(epoch * 1000).toLocaleDateString()}</span>
+        Created: <span>{new Date(epoch * 1000).toLocaleDateString()}</span>
       </p>
+      <Button
+        className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+        variant="ghost"
+        size="square-icon"
+        icon={<Trash2Icon size={20} />}
+        onClick={handleDeleteClick}
+      />
     </div>
   );
 };

--- a/src/components/Layouts/MainLayout/FilesPanel/FilesList.tsx
+++ b/src/components/Layouts/MainLayout/FilesPanel/FilesList.tsx
@@ -1,30 +1,13 @@
 import { useAppContext } from '../../../../contexts/AppProvider';
+import FileItem from './FileItem';
 
 const FilesList = () => {
-  const { files, handleFileSelect, selectedFile } = useAppContext();
-
-  const handleFileClick = (fileName: string) => {
-    console.log(`File clicked: ${fileName}`);
-    handleFileSelect(fileName);
-  };
+  const { files } = useAppContext();
 
   const filesContent = (
-    files.map((file) => {
-      const epoch = Number(file.date_created);
-
-      return (
-        <div
-          key={file.file_name}
-          className={`flex flex-col gap-y-0.5 p-2 hover:bg-gray-bg-hover cursor-pointer rounded-xl relative after:absolute after:bottom-0 after:left-0 after:w-full after:h-px after:bg-border-color/50 after:content-[''] ${file.file_name === selectedFile ? 'bg-gray-bg-active' : ''}`}
-          onClick={() => handleFileClick(file.file_name)}
-        >
-          <h3 className="font-medium">{file.file_name}</h3>
-          <p className="text-sm text-muted-text">
-          Created: <span>{new Date(epoch * 1000).toLocaleDateString()}</span>
-          </p>
-        </div>
-      );
-    })
+    files.map((file) => (
+      <FileItem key={file.file_name} file={file} />
+    ))
   );
 
   return (

--- a/src/components/Layouts/MainLayout/FilesPanel/types.ts
+++ b/src/components/Layouts/MainLayout/FilesPanel/types.ts
@@ -1,0 +1,5 @@
+import { IFileInfo } from '../../../../types/file/fileTypes';
+
+export interface IFileItemProps {
+  file: IFileInfo;
+}

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -9,7 +9,7 @@ interface IAppContext {
   editorMode: EditorModeEnum;
   handleEditorModeChange: (mode: EditorModeEnum) => void;
   files: IFileInfo[];
-  handleFileSelect: (fileName: string) => void;
+  selectFile: (fileName: string) => void;
   selectedFile: string | null;
   fetchFiles: () => Promise<void>;
 }
@@ -26,7 +26,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     setEditorMode(mode);
   };
 
-  const handleFileSelect = (fileName: string) => {
+  const selectFile = (fileName: string) => {
     setSelectedFile(fileName);
   };
 
@@ -112,7 +112,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     editorMode,
     handleEditorModeChange,
     files,
-    handleFileSelect,
+    selectFile,
     selectedFile,
     fetchFiles,
   };

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -37,10 +37,13 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       // Refresh the file list after deletion
       await fetchFiles();
       // If the deleted file was the selected one, clear the content and selection
-      if (selectedFile === fileName) {
-        setSelectedFile(null);
-        setContent('');
-      }
+      setSelectedFile((currentSelectedFile) => {
+        if (currentSelectedFile === fileName) {
+          setContent('');
+          return null;
+        }
+        return currentSelectedFile;
+      });
     } catch (error) {
       console.error('Failed to delete file:', error);
     }

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -10,6 +10,7 @@ interface IAppContext {
   handleEditorModeChange: (mode: EditorModeEnum) => void;
   files: IFileInfo[];
   selectFile: (fileName: string) => void;
+  deleteFile: (fileName: string) => Promise<void>;
   selectedFile: string | null;
   fetchFiles: () => Promise<void>;
 }
@@ -29,6 +30,22 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   const selectFile = (fileName: string) => {
     setSelectedFile(fileName);
   };
+
+  const deleteFile = async (fileName: string) => {
+    try {
+      await invoke('delete_file_by_name', { fileName });
+      // Refresh the file list after deletion
+      await fetchFiles();
+      // If the deleted file was the selected one, clear the content and selection
+      if (selectedFile === fileName) {
+        setSelectedFile(null);
+        setContent('');
+      }
+    } catch (error) {
+      console.error('Failed to delete file:', error);
+    }
+  };
+
 
   const fetchFiles = async () => {
     try {
@@ -113,6 +130,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     handleEditorModeChange,
     files,
     selectFile,
+    deleteFile,
     selectedFile,
     fetchFiles,
   };


### PR DESCRIPTION
closes #47 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds delete buttons to each file and a backend command to remove files. Implements issue #47 so users can delete notes, and the list updates immediately.

- New Features
  - Added `delete_file_by_name` Tauri command to remove `.md` files and return errors when not found.
  - Added a hover-only delete button per file with a confirm prompt.
  - Implemented context `deleteFile` to call the command, refresh the list, and correctly clear editor/selection only when the deleted file is currently open.
  - Refactor: Extracted `FileItem`, added `types.ts`, renamed `handleFileSelect` to `selectFile`, and bumped version to 0.5.2.

- Bug Fixes
  - Moved `stopPropagation` to the start of the delete click handler to prevent unintended file selection.

<sup>Written for commit 9573d8d5aea198649ec523baea117dc39ac7dcea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

