### PR TITLE
51 prepare a framework for claude code

### DIFF
--- a/.claude/agents/tauri-command-author.md
+++ b/.claude/agents/tauri-command-author.md
@@ -1,0 +1,43 @@
+---
+name: tauri-command-author
+description: Use this agent when adding, modifying, or removing a Tauri IPC command (anything reachable via `invoke('name', ...)` from the React frontend). It owns the end-to-end change across `src-tauri/src/lib.rs` and the frontend caller, and enforces the project's filename/IPC conventions. Examples: "add a `rename_file_by_name` command", "expose the markdown export path through IPC", "remove the unused `greet` command".
+tools: Read, Edit, Write, Glob, Grep, Bash
+---
+
+You are the Tauri command author for the Lumark project. Your job is to add, modify, or remove `#[tauri::command]` functions end-to-end so the React frontend can call them.
+
+## Architecture you must respect
+
+- All filesystem I/O lives in `src-tauri/src/lib.rs`. The frontend never touches `fs` — it only calls `invoke('command_name', args)` from `@tauri-apps/api/core`.
+- Files are flat `.md` files in `app.path().app_data_dir()`. The Rust side appends `.md` (`file_path = app_dir.join(file_name + ".md")`). The frontend passes the **base name without extension** — never an already-extended name.
+- `load_files` returns base names via `path.file_stem()`. Keep this contract: frontend identifiers are extension-less.
+
+## Steps for adding a command
+
+1. **Read `src-tauri/src/lib.rs`** to see existing command shapes (`save_content_by_name`, `load_content_by_name`, `add_file`, `delete_file_by_name`, `load_files`). Match the style:
+   - `#[tauri::command]`
+   - Take `app: AppHandle` first, then named arguments
+   - Use `app.path().app_data_dir()` for paths
+   - Return `Result<T, String>` and map all `io::Error`s to descriptive `String`s via `.map_err(|e| format!(...))`
+   - `use std::fs;` inside the function (matches existing style)
+2. **Register the command** in the `invoke_handler![...]` macro list at the bottom of `lib.rs`. Forgetting this is the most common bug — the frontend call will fail at runtime with "command not found".
+3. **Wire the frontend call** through `src/contexts/AppProvider.tsx` if the command affects shared state (files list, selected file, content). Add a method on the context, expose it via the `IAppContext` interface, and surface it in the `value` object. If the call is local to one component, inline `invoke(...)` there instead.
+4. **Refetch state** when a command mutates files (call `await fetchFiles()` after writes/deletes, mirroring `deleteFile`).
+5. **camelCase ↔ snake_case**: Tauri auto-converts. The Rust signature uses `snake_case` parameter names (`file_name`) and the frontend `invoke` call uses `camelCase` (`fileName`). Match this convention — do not pass snake_case keys from JS.
+
+## Steps for removing a command
+
+1. Delete the `fn` in `lib.rs`.
+2. Remove its entry from the `invoke_handler![...]` list.
+3. Grep the frontend for `invoke('<command_name>'` and remove every caller, including any context methods that wrapped it.
+
+## Verification
+
+After changes, run `cargo check --manifest-path src-tauri/Cargo.toml` to catch Rust compile errors, and `yarn lint` for TypeScript. Don't run `yarn tauri dev` — it's a long-running process the user starts themselves.
+
+## What you must NOT do
+
+- Do not introduce file I/O in the frontend — all `fs` work belongs in Rust.
+- Do not pass `.md`-suffixed names across IPC.
+- Do not skip `invoke_handler!` registration.
+- Do not add new state-management libraries — extend `AppProvider.tsx` for shared state.

--- a/.claude/agents/ui-component-author.md
+++ b/.claude/agents/ui-component-author.md
@@ -1,0 +1,49 @@
+---
+name: ui-component-author
+description: Use this agent when creating a new reusable UI primitive under `src/components/UI/` (Button, Input, Modal, Textarea, Card, etc.), or when refactoring feature-specific markup into a shared UI primitive. The agent enforces the project's UI component pattern. Examples: "scaffold a Textarea UI component", "extract this badge markup into a UI primitive", "add a Modal to src/components/UI".
+tools: Read, Edit, Write, Glob, Grep
+---
+
+You are the UI component author for Lumark. You create components in `src/components/UI/` that exactly follow the existing pattern.
+
+## Before scaffolding
+
+Read `src/components/UI/Button/Button.tsx`, `src/components/UI/Button/types.ts`, `src/components/UI/Input/Input.tsx`, and `src/components/UI/Input/types.ts`. They are the reference for the pattern. Match them.
+
+## The pattern (non-negotiable)
+
+1. **File layout**: `src/components/UI/<Name>/<Name>.tsx` + `src/components/UI/<Name>/types.ts`. One folder per component. Export the component as `default`.
+2. **`types.ts`** exports:
+   - The props interface as `I<Name>Props` (capital `I` prefix).
+   - Any string-literal union types the component exposes — e.g. `<Name>SizeType`, `<Name>VariantType`, `<Name>RoundedType`, `<Name>IconPositionType`.
+3. **The props interface extends the native HTML attributes of the root element** so consumers get the full HTML API for free:
+   - `<button>` → `ButtonHTMLAttributes<HTMLButtonElement>`
+   - `<input>` → `InputHTMLAttributes<HTMLInputElement>`
+   - `<textarea>` → `TextareaHTMLAttributes<HTMLTextAreaElement>`
+   - `<a>` → `AnchorHTMLAttributes<HTMLAnchorElement>`
+   - plain `<div>` wrapper → `HTMLAttributes<HTMLDivElement>`
+4. **If the component accepts children**, also `extends PropsWithChildren`. If not (e.g. `Input`), do not.
+5. **Component typed `FC<I<Name>Props>`**. Destructure the named props, leaving `...props` (or `...rest`) to spread.
+6. **Where `{...props}` goes**: onto the **root element by default**, or onto the **most semantically important element when the component wraps its root**. Example: `Input` spreads onto the actual `<input>` inside a wrapper `<div>` because the `<input>` is what callers configure (`value`, `onChange`, `placeholder`, `type`...).
+7. **Multiple `*ClassName` props for flexibility**. Expose one per meaningful structural element rather than a single `className`. Use role-based names: `wrapperClassName`, `labelClassName`, `buttonContainerClassName`, `buttonContentClassName`, `textareaClassName`, `iconWrapperClassName`, etc. Reserve the plain destructured `className` for the root/most-important element so it composes naturally with `{...props}`.
+8. **Variant props use string-literal unions** resolved through a `Record<UnionType, string>` inside `useMemo`, with a default fallback. Example:
+   ```ts
+   const buttonSize = useMemo(() => {
+     const sizeMapping: Record<ButtonSizeType, string> = { xs: '...', sm: '...', md: '...' };
+     return sizeMapping[size] || sizeMapping.md;
+   }, [size]);
+   ```
+9. **Styling is Tailwind utility classes inline** in the JSX. Do not introduce CSS modules, styled-components, CSS-in-JS, or external UI libraries. Color tokens reference custom Tailwind theme variables already defined in `src/assets/css/` (`bg-primary`, `bg-surface`, `text-text-color`, `border-border-color`, `bg-danger`, etc.) — use those instead of raw color literals.
+10. **No emojis** in code or comments.
+11. **No tests** — the repo has no test runner. Do not add one.
+
+## ClassName naming conventions seen in the repo
+
+- `Button`: plain `className` → `<button>` root; `buttonContainerClassName` → inner flex wrapper; `buttonContentClassName` → text wrapper next to icon.
+- `Input`: `wrapperClassName` → outer `<div>`; `labelClassName` → (reserved for a future label); plain `className` → the `<input>` itself.
+
+Pick names with the same shape for new components: think about each layer that someone might reasonably want to style.
+
+## Verification
+
+After writing, run `yarn lint` from the repo root. Fix any lint errors before reporting back.

--- a/.claude/commands/bump-version.md
+++ b/.claude/commands/bump-version.md
@@ -1,0 +1,17 @@
+---
+description: Bump the app's release version in src-tauri/tauri.conf.json (the canonical version source).
+argument-hint: <new-version e.g. 0.5.3 | patch | minor | major>
+allowed-tools: Read, Edit, Bash
+---
+
+Bump the Lumark release version.
+
+Argument: `$ARGUMENTS`
+- If a literal semver like `0.5.3` is given, use it directly.
+- If `patch` / `minor` / `major`, read the current `version` from `src-tauri/tauri.conf.json` and increment accordingly.
+
+Steps:
+1. Read `src-tauri/tauri.conf.json` and note the current `version`.
+2. Compute the new version.
+3. Edit **only** `src-tauri/tauri.conf.json` — this is the canonical version source for the app. Do NOT touch `package.json` (it is intentionally pinned at `0.1.0`) or `src-tauri/Cargo.toml`'s version unless the user explicitly asks.
+4. Report the old → new version change. Do not commit — leave that to the user.

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,0 +1,16 @@
+---
+description: Run the project's quality gates — ESLint (frontend) and cargo check (Rust) — and report failures.
+allowed-tools: Bash, Read
+---
+
+Run the project's quality gates in parallel and report results:
+
+1. `yarn lint` — ESLint on the frontend.
+2. `cargo check --manifest-path src-tauri/Cargo.toml` — Rust compile check (no full build).
+
+Both are read-only / non-mutating. If either fails:
+- Summarize each error with file path and line number.
+- For ESLint errors that are safely auto-fixable, suggest running `yarn lint:fix` but do not run it automatically.
+- For Rust errors, do not attempt fixes unless the user asks — just surface them.
+
+Do not run `yarn build` or `yarn tauri dev` — those are heavier and `tauri dev` is a long-running process the user starts themselves.

--- a/.claude/commands/new-tauri-cmd.md
+++ b/.claude/commands/new-tauri-cmd.md
@@ -1,0 +1,19 @@
+---
+description: Add a new Tauri IPC command end-to-end (Rust handler + invoke_handler registration + frontend wiring).
+argument-hint: <command_name_snake_case> "<brief description>"
+allowed-tools: Read, Edit, Write, Glob, Grep, Bash, Agent
+---
+
+Add a new Tauri command `$1`.
+
+Arguments: `$ARGUMENTS`
+- `$1` = command name in `snake_case` (e.g. `rename_file_by_name`)
+- Remaining args = a brief description of what the command should do.
+
+Delegate to the `tauri-command-author` subagent with:
+- The command name and described behavior.
+- A reminder of the three-step contract: add `#[tauri::command]` to `src-tauri/src/lib.rs`, register it in the `invoke_handler![...]` macro, then wire the frontend caller (typically via `src/contexts/AppProvider.tsx` if it affects shared state).
+- A reminder that the frontend passes **extension-less base names** for file commands; Rust appends `.md`.
+- Instruction to verify with `cargo check --manifest-path src-tauri/Cargo.toml` and `yarn lint`.
+
+Do not implement the command yourself — delegate.

--- a/.claude/commands/new-ui.md
+++ b/.claude/commands/new-ui.md
@@ -1,0 +1,19 @@
+---
+description: Scaffold a new reusable UI primitive under src/components/UI/ following the project pattern.
+argument-hint: <ComponentName> [<root-html-tag>]
+allowed-tools: Read, Edit, Write, Glob, Grep, Agent
+---
+
+Scaffold a new UI primitive at `src/components/UI/$1/` following the project's UI pattern.
+
+Arguments: `$ARGUMENTS`
+- `$1` = component name in PascalCase (e.g. `Textarea`, `Modal`, `Card`)
+- `$2` = optional root HTML tag (e.g. `textarea`, `div`, `dialog`). If omitted, infer from the name.
+
+Delegate to the `ui-component-author` subagent. Hand it:
+- The exact `$1` name and (if given) the `$2` root element.
+- A reminder to read `src/components/UI/Button/` and `src/components/UI/Input/` first as the canonical reference.
+- Instruction to produce `<Name>.tsx` + `types.ts`, with `I<Name>Props` extending the right `*HTMLAttributes<...>` and `PropsWithChildren` only when the element renders children.
+- Instruction to run `yarn lint` after writing.
+
+Do not implement the component yourself — delegate.

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -1,0 +1,42 @@
+# Rules catalog (reference docs)
+
+Standalone rule documents for Lumark. **Each file is a human-browsable reference doc — nothing in this folder is auto-loaded by Claude Code.**
+
+## What auto-loads vs. what doesn't
+
+Claude Code only has two path-related auto-load mechanisms:
+
+| Location | Auto-loads? | When |
+|----------|-------------|------|
+| Root `CLAUDE.md` | yes | every Claude Code session in this repo |
+| Nested `CLAUDE.md` (e.g. `src/components/UI/CLAUDE.md`) | yes | when Claude Code is working inside that subtree |
+| `.claude/rules/*.md` (this folder) | **no** | never automatic — must be opened by hand or pointed at explicitly |
+| `.claude/agents/*.md` | invoked on demand | when an agent matching the task is launched |
+| `.claude/commands/*.md` | invoked on demand | when a user types `/<name>` |
+
+Claude Code has **no Cursor-style `paths:` / `globs:` frontmatter** for scoping rule files to paths — the nested `CLAUDE.md` mechanism is the only path-scoped option. Don't add `paths:` frontmatter to files here; it would be silently ignored and misleading.
+
+## Why keep this folder then?
+
+- A single browsable place for humans (and for `@.claude/rules/<name>.md` references in conversations) to read the canonical rules.
+- Cross-cutting rules (commits, code style, IPC) that don't belong to one folder.
+
+## Index
+
+| Rule | Scope | Authoritative source |
+|------|-------|---------------------|
+| [ui-components.md](./ui-components.md) | `src/components/UI/` | mirrored — `src/components/UI/CLAUDE.md` auto-loads |
+| [tauri-commands.md](./tauri-commands.md) | `src-tauri/` | mirrored — `src-tauri/CLAUDE.md` auto-loads |
+| [global-state.md](./global-state.md) | `src/contexts/` | mirrored — `src/contexts/CLAUDE.md` auto-loads |
+| [editor.md](./editor.md) | `src/components/Editor/` | mirrored — `src/components/Editor/CLAUDE.md` auto-loads |
+| [ipc.md](./ipc.md) | frontend ↔ Rust IPC | this file (cross-cutting, no folder home) |
+| [commits-and-branches.md](./commits-and-branches.md) | git workflow | this file |
+| [code-style.md](./code-style.md) | repo-wide | this file |
+
+**Authority rule**: when a rule file in this folder and its mirrored nested `CLAUDE.md` disagree, **the `CLAUDE.md` wins** — it's the version Claude Code actually loads. Update both in the same PR to keep them in sync.
+
+## How to make a rule actually take effect
+
+- **Path-scoped rule** for some folder → add or update a nested `CLAUDE.md` inside that folder. Optionally mirror it here for browsability.
+- **Repo-wide rule** → add it to the root `CLAUDE.md`. Optionally mirror it here.
+- **A reusable workflow Claude should run on demand** → that's an agent (`.claude/agents/<name>.md`) or a slash command (`.claude/commands/<name>.md`), not a rule.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,62 @@
+# Rule: code style & repo-wide conventions
+
+**Scope**: repo-wide.
+**References**: `eslint.config.mjs`, `package.json`, `src-tauri/tauri.conf.json`.
+
+## Package manager
+
+**Yarn**, not npm. `yarn.lock` is the lockfile of record. Don't commit a `package-lock.json` if one appears.
+
+## ESLint (flat config in `eslint.config.mjs`)
+
+Key style rules — `yarn lint:fix` handles most of these automatically:
+
+- **2-space indent** (`indent: [error, 2, { SwitchCase: 1 }]`).
+- **Single quotes** in TS/JS (`quotes: single`); **double quotes** in JSX attrs (`jsx-quotes: prefer-double`).
+- **Required semicolons** (`semi: always`).
+- **Trailing commas on multiline** (`comma-dangle: always-multiline`).
+- **Arrow body style `as-needed`** — no `() => { return x; }` when `() => x` works.
+- **Object curly spacing `always`** — `{ foo }` not `{foo}`.
+- **Array bracket spacing `never`** — `[1, 2]` not `[ 1, 2 ]`.
+- **No trailing whitespace; final newline required.**
+- `no-console: warn` — prefer `console.error` / `console.warn` over `console.log`.
+- `@typescript-eslint/no-unused-vars: error` with `argsIgnorePattern: '^_'`.
+- `@typescript-eslint/no-explicit-any: warn` — avoid `any` where possible.
+
+Run `yarn lint` before committing. `yarn lint:fix` to auto-fix.
+
+## TypeScript
+
+- React 19 + `tsx` files. `react-in-jsx-scope` is off — don't `import React from 'react'` just for JSX.
+- Prefer named imports from `react`: `import { FC, useMemo, useState } from 'react'`.
+- Type components as `FC<IProps>` when they're simple. The repo doesn't use `React.FC` namespaced — use `FC` from `react`.
+- Interfaces over types for component props (`I<Name>Props`).
+
+## File naming
+
+- React components: `PascalCase.tsx`.
+- Hooks: `useCamelCase.ts`.
+- Types modules: `types.ts` colocated with the component, or `<feature>Types.ts` / `<feature>Enums.ts` under `src/types/<feature>/`.
+
+## No test runner
+
+There is no Jest, Vitest, Playwright, or other test framework configured. Don't add one as part of an unrelated task — propose it as a separate change first.
+
+## No emojis in code
+
+Don't put emojis in source files or commit messages. README and external-facing docs are the only place where emoji is used (and even there, sparingly).
+
+## Versioning quirk
+
+The canonical app version lives in **`src-tauri/tauri.conf.json`** (`"version"` field). `package.json` is intentionally pinned at `0.1.0` and `src-tauri/Cargo.toml` is also pinned at `0.1.0`. When bumping for a release, update `tauri.conf.json` only — leave the other two alone unless the user explicitly asks.
+
+## Comments
+
+Don't add comments that restate what the code does. Only add a comment when the *why* is non-obvious. Don't add JSDoc to ordinary functions.
+
+## Don'ts
+
+- Don't introduce a new state-management library (see [global-state.md](./global-state.md)).
+- Don't introduce a new CSS strategy (CSS modules, styled-components) — Tailwind utility classes only.
+- Don't introduce a new package manager.
+- Don't add `// removed for X` placeholders for deleted code — just delete it.

--- a/.claude/rules/commits-and-branches.md
+++ b/.claude/rules/commits-and-branches.md
@@ -1,0 +1,55 @@
+# Rule: commits & branches
+
+**Scope**: git workflow.
+**References**: `CONTRIBUTING.md`, recent `git log`.
+
+## Branch naming
+
+Branches are created from a GitHub issue using the **"Create a branch"** button on the issue page, then checked out locally. The resulting names look like:
+
+```
+47-add-delete-buttons-to-files
+51-prepare-a-framework-for-claude-code
+```
+
+Format: `<issue#>-<kebab-case-summary>`. Issue number first.
+
+PRs always target `main`.
+
+## Commit messages
+
+Format: `<type>(<issue#>): <subject>`.
+
+Observed types in this repo:
+- `feat` — new feature or feature enhancement
+- `fix` — bug fix
+- `chore` — version bumps, dependency updates, plumbing
+- `doc` — documentation-only changes
+- (Conventional types like `refactor`, `style`, `test`, `perf` are reasonable additions if needed)
+
+Examples:
+```
+feat(47): added delete functionality for files
+fix(47): moved stopPropogation to the top of handleDeleteClick function
+chore(47): bumbed version 0.5.2
+doc(51): add CLAUDE.md with project architecture and UI conventions
+```
+
+The issue number in parentheses comes from the branch name. If a change genuinely has no issue, `doc()` / `chore()` / `feat()` with an empty parens is the observed fallback (see `doc(): added markdown syntax guide to README`).
+
+## What goes in a commit
+
+- One logical change per commit. Subject line should focus on the **why** in 1–2 short phrases.
+- Don't squash unrelated changes together.
+- Run `yarn lint:fix` before committing — see [code-style.md](./code-style.md).
+
+## Tagging / version bumps
+
+The app version lives in `src-tauri/tauri.conf.json` — see [code-style.md](./code-style.md). A version-bump commit should touch only that file (unless lockfiles are also updated by tooling) and use `chore(<issue#>):` as the type.
+
+## Don'ts
+
+- Don't push directly to `main` — open a PR.
+- Don't force-push to `main`.
+- Don't `--amend` published commits; create a new commit instead.
+- Don't skip hooks (`--no-verify`) without a real reason.

--- a/.claude/rules/editor.md
+++ b/.claude/rules/editor.md
@@ -1,0 +1,37 @@
+# Rule: Editor (CodeMirror + Preview)
+
+**Scope**: `src/components/Editor/`.
+**Mirrored at**: `src/components/Editor/CLAUDE.md` (authoritative).
+**References**: `src/components/Editor/Editor.tsx`, `src/components/Editor/EditorMode.tsx`, `src/types/editor/editorEnums.ts`.
+
+The editor mounts **CodeMirror 6 imperatively** alongside a **react-markdown** preview, both driven by the same `content` string from `AppContext`.
+
+## Invariants you must preserve
+
+1. **CodeMirror is constructed once.** The construction effect in `Editor.tsx` has an empty dep array intentionally. Do not add deps — recreating the `EditorView` on every render leaks DOM and destroys cursor state.
+2. **The `#editor-container` DOM node is the mount point** — a single `<div>` that CodeMirror appends into. Don't conditionally unmount the wrapper based on `editorMode`; visibility is controlled via Tailwind `hidden` so the instance survives mode switches.
+3. **`isEditorContentSetInitially` gates the initial doc push** from React `content` → CodeMirror. It's reset to `false` when `selectedFile` changes so the new file's content is pushed once, then edits flow back through the `updateListener` without ping-ponging.
+4. **Updates back into React happen via `updateListener.of(...)`** calling `setContent(update.state.doc.toString())`. Don't introduce a parallel React-side sync.
+5. **Both panes stay mounted in SPLIT mode**; `EDIT` and `PREVIEW` hide the other half via `hidden` + `!w-full`. Don't replace this with conditional rendering — see invariant 2.
+
+## Adding CodeMirror extensions
+
+- Append to `extensions: [...]` in the construction effect.
+- For extensions that need to react to changing React props (theme toggle, etc.), use a [`Compartment`](https://codemirror.net/docs/ref/#state.Compartment) and `editorRef.current.dispatch({ effects: compartment.reconfigure(...) })`. Do *not* add the prop to the construction effect's dep array.
+- New language support → import from `@codemirror/lang-*`. The setup only loads `markdown()` currently.
+
+## Preview pane
+
+- `<ReactMarkdown>` with `remark-gfm`, `rehype-raw`, `rehype-highlight`.
+- Styling: `github-markdown-css` (light variant currently hard-coded) and `highlight.js/styles/github.css`. The light-theme imports are tagged for future-dark-mode — don't remove them without a dark-mode plan.
+- New remark/rehype plugins → append to the existing arrays. Don't build a parallel pipeline.
+
+## EditorMode
+
+`EditorMode.tsx` writes `editorMode` via `handleEditorModeChange` from `AppContext`. New modes start by adding a value to `EditorModeEnum` (`src/types/editor/editorEnums.ts`), then updating both this component and the visibility classes in `Editor.tsx`.
+
+## Don'ts
+
+- Don't swap CodeMirror for `react-simple-code-editor` or similar — the TODO comment about it is exploratory, not a decision.
+- Don't add a debounce in `Editor.tsx` — autosave is already debounced in `AppProvider`.
+- Don't read editor value from `editorRef.current.state.doc.toString()` for anything beyond the existing initial-push comparison; React `content` is the source of truth.

--- a/.claude/rules/global-state.md
+++ b/.claude/rules/global-state.md
@@ -1,0 +1,45 @@
+# Rule: global state (AppProvider)
+
+**Scope**: `src/contexts/`.
+**Mirrored at**: `src/contexts/CLAUDE.md` (authoritative).
+**References**: `src/contexts/AppProvider.tsx`.
+
+## State management
+
+`AppProvider` is the **single** provider for the whole app. No Redux, Zustand, Jotai, or similar.
+
+## How to add shared state
+
+1. Add the state slice and any setters/handlers inside `AppProvider`.
+2. Extend the `IAppContext` interface.
+3. Surface it via the `value` object passed to `<AppContext.Provider>`.
+4. Consumers read it via `useAppContext()` — never by importing `AppContext` directly.
+
+If state is local to one component or subtree, keep it there with `useState`/`useReducer`. Only promote to context when multiple unrelated parts of the UI need it.
+
+## Effect ordering
+
+`AppProvider` runs three effects:
+
+1. On mount → `fetchFiles()` populates `files`.
+2. When `selectedFile` changes → `invoke('load_content_by_name')` and `setContent(...)`.
+3. When `content` *or* `selectedFile` changes → debounced 500 ms autosave via `invoke('save_content_by_name')`.
+
+When touching `content`, watch for:
+
+- **Autosave races**: any write to `content` re-triggers the autosave timer. After deleting the open file, clear `selectedFile` in the same update so autosave doesn't persist the empty buffer back. See `deleteFile` for the pattern.
+- **Initial-load races**: the load effect overwrites `content` whenever `selectedFile` changes. There is no "content ready" signal beyond `selectedFile` being set.
+- **No explicit save**: every keystroke schedules a write. Don't introduce a Save button unless you gate autosave behind it.
+
+## IPC conventions
+
+- `invoke('command_name', { argInCamelCase })` from `@tauri-apps/api/core`. Rust names parameters in `snake_case`; Tauri converts.
+- `await invoke(...)` inside `try/catch`; log failures via `console.error`. ESLint sets `no-console: 'warn'` — prefer `error`/`warn` over `log`.
+- After IPC that mutates the files list, call `await fetchFiles()` to refresh — the Rust side does not push updates.
+
+## Don'ts
+
+- Don't add a second context for ad-hoc state — extend this one.
+- Don't read files directly from the frontend; everything goes through `invoke`.
+- Don't pass `.md`-suffixed names across IPC — see [tauri-commands.md](./tauri-commands.md).
+- Don't replace the debounce without considering existing edit→autosave→reload races.

--- a/.claude/rules/ipc.md
+++ b/.claude/rules/ipc.md
@@ -1,0 +1,56 @@
+# Rule: IPC (frontend ↔ Rust)
+
+**Scope**: cross-cutting — everywhere `invoke()` is called and every `#[tauri::command]`.
+**References**: [tauri-commands.md](./tauri-commands.md), [global-state.md](./global-state.md).
+
+## The contract
+
+- All filesystem I/O lives in `src-tauri/src/lib.rs`. The frontend never touches `fs` directly.
+- Frontend calls Rust *exclusively* via `invoke('command_name', args)` from `@tauri-apps/api/core`.
+- Rust returns `Result<T, String>`; frontend `await`s the `invoke` inside `try/catch`.
+
+## Naming bridge
+
+| Side | Convention | Example |
+|------|------------|---------|
+| Command name | `snake_case` | `delete_file_by_name` |
+| Rust parameter | `snake_case` | `file_name: String` |
+| Frontend `invoke` key | `camelCase` | `{ fileName }` |
+
+Tauri auto-converts between the parameter conventions. Don't pass `snake_case` keys from JS.
+
+## File-identifier contract
+
+The frontend passes file identifiers as **base names without the `.md` extension**. Rust appends it:
+
+```rust
+let file_path = app_dir.join(file_name + ".md");
+```
+
+`load_files` returns `path.file_stem()` strings, also extension-stripped. Breaking this on either side produces `foo.md.md` bugs.
+
+## Adding a new command (end-to-end)
+
+1. Write the `#[tauri::command]` in `src-tauri/src/lib.rs`.
+2. **Register it** in `invoke_handler![...]` at the bottom of `lib.rs` — easiest step to forget, fails at runtime only.
+3. Add a frontend caller. If the command affects shared state (files list, selected file, content), wire it through `src/contexts/AppProvider.tsx`:
+   - Add a method on the context.
+   - Expose it on `IAppContext`.
+   - Include it in the `value` object.
+   - Call `await fetchFiles()` after writes/deletes that change the file list (Rust does not push updates).
+4. If the call is local to one component, inline `invoke(...)` there instead.
+
+## Removing a command
+
+1. Delete the `fn` in `lib.rs`.
+2. Remove its entry from `invoke_handler![...]`.
+3. Grep the frontend for `invoke('<command_name>'` and remove every caller and any context method wrapping it.
+
+## Error handling
+
+- Rust: map every `io::Error` to a descriptive `String` via `.map_err(|e| format!(...))`. Don't `.unwrap()`.
+- Frontend: `try/catch` around every `invoke`; on failure log via `console.error('Failed to <action>:', error)` and recover sensibly (e.g. set empty `content`, clear selection). ESLint warns on `console.log` — prefer `error`/`warn`.
+
+## Verification
+
+`cargo check --manifest-path src-tauri/Cargo.toml` and `yarn lint`.

--- a/.claude/rules/tauri-commands.md
+++ b/.claude/rules/tauri-commands.md
@@ -1,0 +1,69 @@
+# Rule: Tauri / Rust backend
+
+**Scope**: `src-tauri/`.
+**Mirrored at**: `src-tauri/CLAUDE.md` (authoritative).
+**References**: `src-tauri/src/lib.rs` (existing commands), `src-tauri/tauri.conf.json`.
+
+## Where things go
+
+- All `#[tauri::command]` functions live in `src-tauri/src/lib.rs`. Don't split them across new modules without a real reason — the file is still small.
+- `main.rs` is the binary entry; it only calls into `lib.rs`.
+- New Tauri plugins go in `Cargo.toml` and are initialised inside `run()` (see `tauri_plugin_opener::init()` for the pattern).
+- Native config (window, bundle, identifier) lives in `tauri.conf.json`.
+
+## Command shape (match the existing functions)
+
+```rust
+#[tauri::command]
+fn <snake_case_name>(app: AppHandle, <named_args>) -> Result<T, String> {
+    use std::fs;
+
+    let app_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+
+    // ... work ...
+
+    Ok(value)
+}
+```
+
+- Take `app: AppHandle` first when you need the data dir.
+- Return `Result<T, String>` and map every `io::Error` via `.map_err(|e| format!(...))`. Don't `unwrap`.
+- Use `app.path().app_data_dir()` — never absolute paths or `std::env::current_dir()`.
+- `use std::fs;` inside the function (matches existing style — no top-of-file `use`).
+
+## The three-step contract
+
+1. Write the `#[tauri::command]` fn.
+2. **Register it** in the `invoke_handler![...]` macro list at the bottom of `lib.rs`. Forgetting this fails at runtime with "command not found" — the compiler does not catch it.
+3. Wire the frontend caller — usually through `src/contexts/AppProvider.tsx` if it touches shared state.
+
+## Naming
+
+- Rust parameter names: `snake_case` (e.g. `file_name`).
+- Frontend `invoke` argument keys: `camelCase` (e.g. `fileName`). Tauri auto-converts.
+- Command names: `snake_case` (e.g. `delete_file_by_name`).
+
+## File-extension contract
+
+The frontend identifies files by their **base name without the `.md` extension**. The Rust side appends:
+
+```rust
+let file_path = app_dir.join(file_name + ".md");
+```
+
+`load_files` returns base names via `path.file_stem()`. Passing an already-extended name from JS produces `foo.md.md`.
+
+## Don'ts
+
+- Don't introduce file I/O in the frontend; it belongs here.
+- Don't `.unwrap()` on `io::Result` — map to `String`.
+- Don't change the extension contract without updating every command and every frontend caller in the same change.
+- Don't make commands async unless they actually need to be.
+- Don't add `tokio`, `serde_yaml`, etc., without a real need — deps are intentionally minimal.
+
+## Verification
+
+`cargo check --manifest-path src-tauri/Cargo.toml`. `cargo clippy` optional but welcome.

--- a/.claude/rules/ui-components.md
+++ b/.claude/rules/ui-components.md
@@ -1,0 +1,45 @@
+# Rule: UI primitive components
+
+**Scope**: `src/components/UI/` — Lumark's in-house UI library.
+**Mirrored at**: `src/components/UI/CLAUDE.md` (authoritative).
+**References**: `src/components/UI/Button/`, `src/components/UI/Input/`.
+
+## When to add a component to `src/components/UI/`
+
+- **Yes**: reusable presentational primitive (button, input, modal, textarea, card, badge, tooltip…). It has UI sense beyond any one feature.
+- **No**: feature-specific markup (a file row, the editor toolbar). Keep that next to the feature.
+
+Before writing new markup elsewhere, scan `src/components/UI/` first and reuse what exists. If a primitive is missing, add it here rather than reaching for an external UI library.
+
+## The pattern (non-negotiable)
+
+1. **File layout**: `<Name>/<Name>.tsx` + `<Name>/types.ts`. One folder per component. `export default` the component.
+2. **`types.ts`** exports:
+   - `I<Name>Props` (capital `I` prefix).
+   - String-literal union types — `<Name>SizeType`, `<Name>VariantType`, `<Name>RoundedType`, `<Name>IconPositionType`, etc.
+3. **`I<Name>Props` extends the native HTML attributes of the root element**:
+   - `<button>` → `ButtonHTMLAttributes<HTMLButtonElement>`
+   - `<input>` → `InputHTMLAttributes<HTMLInputElement>`
+   - `<textarea>` → `TextareaHTMLAttributes<HTMLTextAreaElement>`
+   - `<a>` → `AnchorHTMLAttributes<HTMLAnchorElement>`
+   - plain `<div>` wrapper → `HTMLAttributes<HTMLDivElement>`
+4. **Also extend `PropsWithChildren` only when the component renders children**. `Button` does; `Input` does not.
+5. **Component is `FC<I<Name>Props>`**. Destructure your own named props, leave `...props` (or `...rest`) for spreading.
+6. **Where `{...props}` goes**: onto the **root element by default**, or onto the **most semantically important element when the component wraps its root**. `Input` spreads onto its `<input>` inside a wrapper `<div>` because the `<input>` is what callers configure (`value`, `onChange`, `placeholder`, `type`…).
+7. **Multiple `*ClassName` props** for flexibility — one per meaningful structural layer, named for its role: `wrapperClassName`, `labelClassName`, `buttonContainerClassName`, `buttonContentClassName`, `textareaClassName`, `iconWrapperClassName`. The plain destructured `className` is reserved for the root/most-important element so it composes with `{...props}`.
+8. **Variant props are string-literal unions** mapped through a `Record<UnionType, string>` inside `useMemo`, with a fallback to a sensible default:
+   ```ts
+   const buttonSize = useMemo(() => {
+     const sizeMapping: Record<ButtonSizeType, string> = { xs: '...', sm: '...', md: '...' };
+     return sizeMapping[size] || sizeMapping.md;
+   }, [size]);
+   ```
+9. **Styling is inline Tailwind utility classes**. No CSS modules, styled-components, CSS-in-JS, or external UI libs.
+10. **Theme tokens**: use Tailwind variables defined in `src/assets/css/` — `bg-surface`, `text-text-color`, `border-border-color`, `bg-primary` (+ `-hover`/`-active`), `bg-danger`, `bg-success`, `bg-warning`, `bg-info`, `bg-secondary`, `text-danger`, etc. No hardcoded hex.
+
+## Don'ts
+
+- Don't import `react-icons` or large icon libraries — the project uses `lucide-react`.
+- Don't add `forwardRef` unless a consumer actually needs the ref.
+- Don't add a story or test file — no Storybook/test runner exists.
+- Don't put emojis in component code.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "enabledMcpjsonServers": ["context7"],
+  "permissions": {
+    "allow": [
+      "Bash(yarn install)",
+      "Bash(yarn lint)",
+      "Bash(yarn lint:fix)",
+      "Bash(yarn build)",
+      "Bash(yarn dev)",
+      "Bash(yarn tauri:*)",
+      "Bash(npx tsc:*)",
+      "Bash(cargo check:*)",
+      "Bash(cargo build:*)",
+      "Bash(cargo fmt:*)",
+      "Bash(cargo clippy:*)",
+      "Bash(git status)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git show:*)",
+      "Bash(git add:*)",
+      "mcp__context7__resolve-library-id",
+      "mcp__context7__query-docs"
+    ]
+  }
+}

--- a/.claude/skills/codemirror-extension-adder/SKILL.md
+++ b/.claude/skills/codemirror-extension-adder/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: codemirror-extension-adder
+description: Use when adding a CodeMirror 6 extension to the editor — phrases like "add Tab/Shift+Tab support", "add a keymap", "support Ctrl+B for bold", "add a dark theme toggle", "swap the CodeMirror theme", "add a CodeMirror extension". Several roadmap items (Tab support, key shortcuts, dark mode for the editor) all flow through this skill. Enforces the lifecycle invariants documented in `src/components/Editor/CLAUDE.md`.
+---
+
+# CodeMirror extension adder
+
+You're adding a CodeMirror 6 extension to Lumark's editor. The construction is **imperative** (not React-controlled), and the React-side state has subtle race conditions with the autosave, so a few invariants matter.
+
+## Read first
+
+- `src/components/Editor/Editor.tsx` — the existing `EditorView` construction.
+- `src/components/Editor/CLAUDE.md` — the lifecycle invariants (read all five).
+
+## Decide: static or reactive?
+
+**Static extension** = configured once, never needs to change for the lifetime of the editor. Examples:
+- `EditorView.lineWrapping`
+- `markdown()` language support
+- `basicSetup`
+- A new keymap that's always on
+
+**Reactive extension** = depends on a changing React prop / state. Examples:
+- Theme that toggles light ↔ dark
+- A keymap that depends on a feature flag
+- Read-only mode toggle
+
+Picking wrong is the most common bug.
+
+## Static extension — append to the array
+
+```ts
+const startState = EditorState.create({
+  doc: content || '',
+  extensions: [
+    basicSetup,
+    EditorView.lineWrapping,
+    markdown(),
+    githubLight,
+    EditorView.updateListener.of((update) => {
+      if (update.docChanged) {
+        setContent(update.state.doc.toString());
+      }
+    }),
+    <YOUR NEW EXTENSION HERE>,
+  ],
+});
+```
+
+That's the entire change. Do **not** add the new prop to the construction `useEffect`'s dep array (invariant #1: the editor is constructed once).
+
+### Example: Tab / Shift+Tab support (roadmap item)
+
+```ts
+import { keymap } from '@codemirror/view';
+import { indentWithTab } from '@codemirror/commands';
+
+// in extensions:[]
+keymap.of([indentWithTab]),
+```
+
+### Example: extra keymap entries
+
+```ts
+import { keymap } from '@codemirror/view';
+
+keymap.of([
+  { key: 'Ctrl-b', run: (view) => { /* wrap selection in ** */ return true; } },
+  { key: 'Ctrl-i', run: (view) => { /* wrap selection in * */ return true; } },
+]),
+```
+
+## Reactive extension — use a `Compartment`
+
+For anything that needs to change after construction (theme toggle, read-only flag), use a `Compartment`. Do not destroy and recreate the `EditorView`.
+
+```ts
+import { Compartment } from '@codemirror/state';
+import { githubLight } from '@fsegurai/codemirror-theme-github-light';
+import { githubDark } from '@fsegurai/codemirror-theme-github-dark';
+
+// hoist outside the component, or store on a ref:
+const themeCompartment = useRef(new Compartment()).current;
+
+// in the construction effect:
+extensions: [
+  // ...
+  themeCompartment.of(githubLight), // initial value
+]
+
+// in a separate effect that watches the React prop:
+useEffect(() => {
+  if (!editorRef.current) return;
+  editorRef.current.dispatch({
+    effects: themeCompartment.reconfigure(isDark ? githubDark : githubLight),
+  });
+}, [isDark]);
+```
+
+Key points:
+- The `Compartment` instance must be stable across renders — use `useRef` or define it outside the component.
+- The watching effect lives **separate from** the construction effect. Construction stays one-time.
+- Use `dispatch({ effects: compartment.reconfigure(...) })`, not `dispatch({ changes: ... })`.
+
+## Adding language support
+
+```ts
+import { python } from '@codemirror/lang-python';
+```
+
+Then append `python()` to `extensions:[]`. Note: Lumark is a Markdown editor — adding other language support is unusual. Confirm intent with the user.
+
+## What you must NOT do
+
+- **Do not add deps to the construction effect's dep array.** That recreates the `EditorView` on every render, leaks DOM, and resets cursor state.
+- **Do not introduce a parallel React-side sync** between `content` and the editor. The single source of truth is `setContent` called from the `updateListener` extension.
+- **Do not add a debounce in `Editor.tsx`.** Autosave is already debounced in `AppProvider` (500 ms). Stacking debounces compounds latency.
+- **Do not destroy and recreate the editor** when a config prop changes — that's what `Compartment` is for.
+
+## Theme tokens
+
+The current theme is `@fsegurai/codemirror-theme-github-light`. The dark variant `@fsegurai/codemirror-theme-github-dark` is already in `package.json` and imported in a comment for future dark-mode work — wire it via Compartment when dark mode lands.
+
+## Verification
+
+After changes:
+1. `yarn lint`
+2. Manually test in `yarn tauri dev`: open a file, edit it, switch files, toggle modes (SPLIT/EDIT/PREVIEW). The cursor position should survive mode switches because both panes stay mounted (invariant #2/#5).
+
+If the user can't manually test, **say so explicitly** in the report — don't claim success for an editor change without running it.
+
+## Don'ts (roundup)
+
+- Don't add the new prop to the construction effect's dep array.
+- Don't add `useEffect`s that read `content` and write back to it.
+- Don't introduce a second autosave debounce.
+- Don't swap CodeMirror for `react-simple-code-editor` even though there's an exploratory TODO comment about it.

--- a/.claude/skills/committer/SKILL.md
+++ b/.claude/skills/committer/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: committer
+description: Use when the user asks to commit changes, create a commit, or stage and commit. Drafts a commit message following Lumark's `<type>(<issue#>): <subject>` convention, deriving the issue number from the current branch name (e.g. branch `47-add-delete-buttons-to-files` → `(47)`). Selects `feat` / `fix` / `chore` / `doc` based on what's changed.
+---
+
+# Committer
+
+You are committing changes in the Lumark repo. Follow these steps.
+
+## 1. Inspect the working state in parallel
+
+Run in a single message:
+- `git status` (no `-uall` flag — it's a large repo)
+- `git diff` (staged + unstaged)
+- `git log --oneline -10` (to match style)
+- `git branch --show-current` (to extract the issue number)
+
+## 2. Derive the issue number
+
+Branch names follow `<issue#>-<kebab-case-summary>` (e.g. `47-add-delete-buttons-to-files`, `51-prepare-a-framework-for-claude-code`). The issue number is the leading integer.
+
+- If the branch matches that pattern → use `(<n>)`.
+- If the branch is `main` or doesn't start with a number → use empty parens `()` (the repo has precedent: `doc(): added markdown syntax guide to README`).
+
+## 3. Choose the type
+
+| Type | When |
+|------|------|
+| `feat` | new feature or feature enhancement |
+| `fix` | bug fix |
+| `chore` | version bumps, dep updates, plumbing, build config |
+| `doc` | documentation-only changes (README, CLAUDE.md, comments) |
+
+For mixed changes, pick the dominant one. Don't invent new types without checking `git log`.
+
+## 4. Write the subject
+
+- 1–2 short phrases describing the change in active voice.
+- Focus on **why** more than what when possible (the diff shows what).
+- Match the casing of recent commits (the repo log uses lowercase for subject text).
+- Keep under ~70 chars if possible.
+
+## 5. Stage and commit
+
+- Stage specific files by name. Avoid `git add -A` / `git add .` unless the user asks — could pick up `.env`, build artifacts, etc.
+- Never commit files that look sensitive (`.env`, credentials, keys). Warn the user if they explicitly ask.
+- Use a HEREDOC for the message so formatting is preserved:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<type>(<issue#>): <subject>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- Never use `--no-verify`, `--no-gpg-sign`, or `--amend` unless the user explicitly asked. If a hook fails, fix the underlying issue and create a NEW commit.
+
+## 6. Verify
+
+After commit, run `git status` to confirm the commit landed and the tree is in the expected state.
+
+## Don'ts
+
+- Don't push unless asked.
+- Don't open a PR unless asked.
+- Don't squash unrelated changes into one commit — propose splitting first.
+- Don't bump the version (`src-tauri/tauri.conf.json`) as part of an unrelated commit.

--- a/.claude/skills/docs-explorer/SKILL.md
+++ b/.claude/skills/docs-explorer/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: docs-explorer
+description: Use whenever the user asks about a library, framework, SDK, API, CLI tool, or cloud service — even well-known ones (React, Tauri, CodeMirror, Tailwind, Vite, ESLint, lucide-react, react-markdown, remark, rehype, Rust crates, etc.). Includes API syntax, configuration, version migration, library-specific debugging, setup, CLI usage. ALWAYS consults Context7 (`mcp__context7__*`, configured in `.mcp.json`) — never relies on training data for library docs. Skip for: refactoring, writing scripts from scratch, debugging business logic, general programming concepts.
+---
+
+# Docs explorer
+
+You are answering a question about an external library, framework, or tool. Your job is to fetch **current** documentation via the Context7 MCP server rather than relying on your training data, which may be out of date.
+
+## When to use this skill
+
+- Library / framework API questions ("how do I use the Tauri AppHandle?", "what's the CodeMirror v6 way to add a keymap?")
+- Version migration ("how do I upgrade from Tauri 1 to 2?", "what changed in React 19?")
+- Configuration / setup ("Tailwind v4 config", "Vite plugin order")
+- Library-specific debugging ("why is my `remark-gfm` plugin not picking up tables?")
+- CLI tool usage ("`tauri build` flags", "`cargo clippy` options")
+
+## When NOT to use this skill
+
+- Refactoring or writing scripts from scratch (no specific library API needed)
+- Debugging business logic
+- Code review
+- General programming concepts (algorithms, data structures, language fundamentals)
+
+## Workflow — always two tools
+
+### Step 1: resolve the library
+
+Call `mcp__context7__resolve-library-id` with the library name. This gives you the canonical Context7 ID.
+
+**If `mcp__context7__*` tools aren't available**: the local `.mcp.json` is missing (it's gitignored — see root `CLAUDE.md`). Ask the user to run `cp .mcp.example.json .mcp.json` and restart Claude Code. If you also see `mcp__claude_ai_Context7__*` tools from a personal claude.ai connection, you may use those as a fallback for the current session.
+
+Examples to map first:
+- "Tauri" → look up `tauri-apps/tauri` (or v2-specific id)
+- "CodeMirror" → look up `codemirror/codemirror` or specific package like `@codemirror/lang-markdown`
+- "React" → `facebook/react`
+- "Tailwind" → `tailwindlabs/tailwindcss`
+- "react-markdown" → `remarkjs/react-markdown`
+
+If the user mentions a specific version (e.g. "Tauri v2", "Tailwind v4", "React 19"), include that in the resolution query — version pinning matters.
+
+### Step 2: query the docs
+
+Call `mcp__context7__query-docs` with the resolved library id and the user's specific question. Provide:
+- The library id from step 1.
+- A targeted query (not just the library name) — e.g. "AppHandle data_dir method" not just "Tauri".
+
+### Step 3: synthesise an answer
+
+Quote/cite the docs you retrieved. Don't invent API signatures or flags — if the docs don't cover it, say so and suggest where the user can look (GitHub source, issue tracker).
+
+## Don'ts
+
+- **Don't skip Context7** even when you "know" the answer. Your training data has a cutoff and libraries move fast (especially React 19, Tauri 2, Tailwind 4, all of which Lumark uses).
+- **Don't use WebSearch as a first resort** for library docs. Context7 is more authoritative and curated.
+- **Don't conflate versions.** Lumark uses Tauri v2 — don't return v1 examples. Tailwind v4 — don't return v3 syntax. React 19 — don't return React 17 patterns.
+- **Don't answer for libraries that aren't actually used in Lumark** without flagging it. If the user asks about a library not in `package.json` / `Cargo.toml`, point that out.
+
+## Lumark's library inventory (for quick reference)
+
+Frontend (`package.json`):
+- React 19, ReactDOM 19
+- Tauri 2 (`@tauri-apps/api`, `@tauri-apps/plugin-opener`)
+- Vite 7, `@vitejs/plugin-react`
+- Tailwind 4 (`@tailwindcss/vite`, `@tailwindcss/typography`)
+- CodeMirror 6 (`codemirror`, `@codemirror/lang-markdown`, `@codemirror/highlight`, `@codemirror/state`, `@codemirror/view`)
+- CodeMirror themes: `@fsegurai/codemirror-theme-github-light` / `-dark`
+- `react-markdown`, `remark-gfm`, `rehype-raw`, `rehype-highlight`
+- `github-markdown-css`, `highlight.js`
+- `lucide-react` (icons)
+- ESLint 9 flat config, TypeScript 5.8
+
+Rust (`src-tauri/Cargo.toml`):
+- `tauri = "2"`, `tauri-plugin-opener = "2"`, `serde`, `serde_json`
+
+Match the question to one of these when relevant.

--- a/.claude/skills/eslint-fixer/SKILL.md
+++ b/.claude/skills/eslint-fixer/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: eslint-fixer
+description: Use when `yarn lint` reports errors or warnings, or when the user asks to fix lint issues, format code, or clean up style. Triggers on phrases like "fix lint errors", "the linter is failing", "run lint:fix", "clean up style". Reads `eslint.config.mjs` to understand which rules apply and respects existing repo conventions.
+---
+
+# ESLint fixer
+
+You're cleaning up ESLint errors / warnings in the Lumark repo. The flat config lives at `eslint.config.mjs`.
+
+## Workflow
+
+### Step 1: see what's failing
+
+```bash
+yarn lint
+```
+
+Parse the output. ESLint errors come in pairs of `file:line:col  error  <message>  <rule-id>`. Group by file.
+
+### Step 2: try the easy path first
+
+For purely stylistic violations (indentation, quotes, semicolons, trailing commas, brace style, spacing), run:
+
+```bash
+yarn lint:fix
+```
+
+Then re-run `yarn lint` to see what's left.
+
+### Step 3: hand-fix the remainder
+
+These are the rules that `--fix` cannot auto-correct — handle them by hand:
+
+| Rule | Fix |
+|------|-----|
+| `@typescript-eslint/no-unused-vars` | Delete the unused variable. If it's a function arg that *must* be present (e.g. a callback signature), rename it with a `_` prefix. |
+| `@typescript-eslint/no-explicit-any` (warn) | Replace `any` with the real type. If genuinely unknown, use `unknown` and narrow at the use site. |
+| `react-hooks/exhaustive-deps` (warn) | Add the missing dep to the dep array — but check the effect's semantics first. If the dep would cause an infinite loop, you may need to refactor (use a ref, useCallback, etc.) rather than just adding the dep. |
+| `react-refresh/only-export-components` (warn) | Move non-component exports (constants, helpers) into a separate file. Or use `export const x = { ... } as const` and accept the warning if it's a constant. |
+| `no-console` (warn) | Use `console.error` / `console.warn` for error paths. Remove `console.log` debug statements. |
+| `react/jsx-key` | Add a stable `key={...}` to each mapped element. Don't use the array index unless the list is provably static. |
+
+### Step 4: verify
+
+Re-run `yarn lint` until it's clean. Don't leave warnings unaddressed unless the user explicitly accepts them — ESLint's `react-hooks/exhaustive-deps` warnings in particular can mask real bugs.
+
+## Key style rules (in case `--fix` is unavailable)
+
+- 2-space indent (`SwitchCase: 1`)
+- Single quotes in TS/JS; double quotes in JSX attrs
+- Required semicolons
+- Trailing commas on multiline
+- `arrow-body-style: as-needed` — no `() => { return x; }`
+- `object-curly-spacing: always` — `{ foo }` not `{foo}`
+- `array-bracket-spacing: never` — `[1, 2]` not `[ 1, 2 ]`
+- No trailing whitespace; final newline required
+
+## Special cases
+
+- **`react-hooks/exhaustive-deps` in `AppProvider.tsx`**: this file has effects with intentionally empty dep arrays (e.g. the on-mount `fetchFiles`). If the linter flags one, check `src/contexts/CLAUDE.md` before "fixing" — the empty array may be load-bearing.
+- **`react-hooks/exhaustive-deps` in `Editor.tsx`**: the construction effect has an empty dep array on purpose to avoid recreating the CodeMirror `EditorView`. See `src/components/Editor/CLAUDE.md` invariant #1.
+
+## Don'ts
+
+- Don't disable rules with `// eslint-disable-next-line` without a comment explaining why. Prefer a real fix.
+- Don't edit `eslint.config.mjs` to silence rules unless the user asks.
+- Don't reformat unrelated code while fixing a specific error — keep the diff minimal.
+- Don't run `yarn lint:fix` and commit without re-running `yarn lint` afterwards.

--- a/.claude/skills/ipc-command-creator/SKILL.md
+++ b/.claude/skills/ipc-command-creator/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: ipc-command-creator
+description: Use when the user wants to add a new Tauri IPC command — anything reachable via `invoke('name', ...)` from React. Triggers on phrases like "add a Tauri command", "expose X to the frontend", "create a new `#[tauri::command]`", "add IPC for Y". Enforces the three-step contract (Rust fn + invoke_handler! registration + frontend wiring) and the file-extension contract.
+---
+
+# IPC command creator
+
+Adds a new Tauri command end-to-end. Read `src-tauri/CLAUDE.md` and `.claude/rules/ipc.md` for the full rules — this skill summarises the workflow.
+
+## Reference existing commands first
+
+Open `src-tauri/src/lib.rs` and skim the existing commands (`save_content_by_name`, `load_content_by_name`, `add_file`, `delete_file_by_name`, `load_files`). Match their shape exactly.
+
+## The three-step contract — all three are required
+
+### Step 1: Add the `#[tauri::command]` to `src-tauri/src/lib.rs`
+
+```rust
+#[tauri::command]
+fn <snake_case_name>(app: AppHandle, <named_args>) -> Result<T, String> {
+    use std::fs;
+
+    let app_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+
+    // ... work ...
+
+    Ok(value)
+}
+```
+
+Rules:
+- `app: AppHandle` first when you need the data dir.
+- Return `Result<T, String>`; map every `io::Error` via `.map_err(|e| format!(...))`. Don't `unwrap`.
+- `use std::fs;` inside the function (matches existing style).
+- Parameter names in `snake_case`.
+
+### Step 2: Register in `invoke_handler![...]`
+
+At the bottom of `lib.rs`. Easy to forget. If you skip this, the frontend call fails at runtime with "command not found" — the compiler does not catch it.
+
+```rust
+.invoke_handler(tauri::generate_handler![
+    greet,
+    save_content,
+    load_content,
+    add_file,
+    load_files,
+    load_content_by_name,
+    save_content_by_name,
+    delete_file_by_name,
+    <your_new_command_here>
+])
+```
+
+### Step 3: Wire the frontend caller
+
+If the command affects shared state (files list, selected file, content), wire it through `src/contexts/AppProvider.tsx`:
+
+1. Add an async method (e.g. `renameFile`) inside the provider.
+2. Inside it: `await invoke('<command_name>', { argInCamelCase })` inside `try/catch`.
+3. After writes/deletes, `await fetchFiles()` to refresh — Rust does not push updates.
+4. Extend the `IAppContext` interface with the new method.
+5. Include it in the `value` object.
+6. Consumers call it via `useAppContext()`.
+
+If the call is local to one component, inline `invoke(...)` there instead.
+
+## File-identifier contract
+
+The frontend passes file identifiers as **base names without the `.md` extension**. The Rust side appends:
+
+```rust
+let file_path = app_dir.join(file_name + ".md");
+```
+
+Passing an already-extended name from JS produces `foo.md.md`. Do not break this.
+
+## Naming bridge
+
+| Side | Convention | Example |
+|------|-----------|---------|
+| Command name | `snake_case` | `rename_file_by_name` |
+| Rust parameter | `snake_case` | `file_name: String` |
+| Frontend `invoke` key | `camelCase` | `{ fileName }` |
+
+Tauri auto-converts. Don't pass `snake_case` keys from JS.
+
+## Verification
+
+After changes:
+- `cargo check --manifest-path src-tauri/Cargo.toml`
+- `yarn lint`
+
+## Delegation
+
+For non-trivial work, consider delegating to the `tauri-command-author` subagent (`.claude/agents/tauri-command-author.md`) which has the same context but works in a separate window.
+
+## Don'ts
+
+- Don't introduce file I/O on the frontend.
+- Don't `.unwrap()` on `io::Result` — map to `String`.
+- Don't add an async command unless it actually needs to be.
+- Don't add new crates without a real need (`tokio`, `serde_yaml`, etc.).

--- a/.claude/skills/ipc-command-invoker/SKILL.md
+++ b/.claude/skills/ipc-command-invoker/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: ipc-command-invoker
+description: Use when the user wants to **call an existing Tauri command** from a new place in the frontend — adding a button that loads a file, a UI action that triggers an existing IPC, etc. Distinct from creating a new command. Triggers on phrases like "call `load_files` from this component", "wire up the existing IPC", "invoke X from the frontend". For creating NEW commands, use `ipc-command-creator` instead.
+---
+
+# IPC command invoker
+
+You're adding a frontend caller for an already-registered Tauri command. No Rust changes needed.
+
+## Step 0: confirm the command exists
+
+Open `src-tauri/src/lib.rs`. Verify:
+1. The command is defined as `#[tauri::command]`.
+2. It is listed in the `invoke_handler![...]` macro at the bottom.
+
+If either is missing, you're in the wrong skill — switch to `ipc-command-creator`.
+
+Note the exact:
+- Command name (snake_case)
+- Parameter names (snake_case)
+- Return type
+
+## Step 1: write the `invoke` call
+
+Import once at the top of the file:
+
+```ts
+import { invoke } from '@tauri-apps/api/core';
+```
+
+Call inside an async function with `try/catch`:
+
+```ts
+try {
+  const result = await invoke<ReturnType>('command_name', { argInCamelCase: value });
+  // use result
+} catch (error) {
+  console.error('Failed to <action>:', error);
+}
+```
+
+### Required conventions
+
+- **Camel-case the keys**. The Rust param `file_name` is `fileName` on the JS side. Tauri auto-converts.
+- **Type the return value** via the `invoke<T>(...)` generic. The Rust return type is `Result<T, String>` — successful resolution gives you `T`, errors throw with the `String` as the message.
+- **Wrap in try/catch**. Every Rust command can fail; ESLint warns on `console.log`, so use `console.error`/`console.warn`.
+
+## Step 2: decide where the call lives
+
+- **Affects shared state** (current file, content, files list)? Add the call as a method on `AppProvider` (`src/contexts/AppProvider.tsx`):
+  - Add the method body.
+  - Extend `IAppContext`.
+  - Include it on the `value` object.
+  - Consumers call via `useAppContext()`.
+  - If it mutates the file list, follow up with `await fetchFiles()`.
+- **Purely local** to one component (e.g. opening an external URL, copying a one-off blob)? Inline the `invoke` in the component.
+
+## Step 3: file-identifier reminder
+
+If the command takes a file name, pass the **base name without `.md`**. The Rust side appends the extension. See `load_content_by_name`, `delete_file_by_name`, etc.
+
+## Verification
+
+`yarn lint` — that's enough for a frontend-only change.
+
+## Don'ts
+
+- Don't `import { fs } from '...'` on the frontend. All filesystem work goes through IPC.
+- Don't bypass `AppProvider` for state-affecting calls — keep state flow consistent.
+- Don't pass `snake_case` keys to `invoke` — Tauri does the conversion for you.
+- Don't pass `.md`-suffixed file names.

--- a/.claude/skills/issue-starter/SKILL.md
+++ b/.claude/skills/issue-starter/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: issue-starter
+description: Use when the user wants to start work on a specific GitHub issue — phrases like "let's work on issue #51", "start issue 47", "tackle #29", "begin work on the dark-mode issue". Fetches the issue with `gh issue view`, creates a branch following Lumark's `<issue#>-<kebab-summary>` convention, and summarises the scope. Mirrors steps 1–3 of CONTRIBUTING.md.
+---
+
+# Issue starter
+
+You're starting work on a GitHub issue. Set up the branch and orient the user (or yourself) on what's needed.
+
+## 1. Identify the issue number
+
+From the user's message — `#51`, `issue 51`, `51-`, etc. If ambiguous or missing, ask.
+
+## 2. Fetch the issue
+
+```bash
+gh issue view <n>
+```
+
+If the user doesn't have `gh` authenticated or the command fails, ask them to authenticate (`gh auth login` — they need to run this themselves with `! gh auth login`) or paste the issue text manually.
+
+Capture from the output:
+- **Title** — used to generate the branch name.
+- **Body** — used to summarise scope.
+- **Labels** — if `good first issue` / `bug` / `enhancement`, mention to the user.
+- **State** — if `closed`, stop and surface that to the user before doing anything else.
+
+## 3. Verify the current branch is clean and based on main
+
+In parallel:
+```bash
+git status
+git branch --show-current
+```
+
+Then:
+- If the tree is dirty, stop and surface the changes. Don't auto-stash unless asked.
+- If the current branch isn't `main`, ask before checking out main.
+- Optional but recommended: `git fetch origin main` to see if local main is behind. Don't pull without asking.
+
+## 4. Create the branch
+
+Format: `<issue#>-<kebab-case-summary>`. Examples seen in this repo:
+- `47-add-delete-buttons-to-files`
+- `51-prepare-a-framework-for-claude-code`
+
+Derive the kebab-case summary from the issue title:
+- Lowercase
+- Replace spaces with `-`
+- Strip non-alphanumeric (except `-`)
+- Drop filler words sparingly (keep titles recognisable; don't aggressively truncate)
+- Aim for 3–6 words
+
+If the GitHub "Create a branch" button has already generated a name on the issue page, prefer that exact string (the user can paste it). Otherwise generate one and show it to the user before creating.
+
+```bash
+git checkout -b <issue#>-<kebab-summary>
+```
+
+## 5. Summarise the scope
+
+After branch is created, give the user a short orientation:
+- One-paragraph summary of what the issue asks for.
+- 2–5 bullets listing the files / areas likely to change. Use the project's structure:
+  - File operations → `src-tauri/src/lib.rs` + `src/contexts/AppProvider.tsx`
+  - Editor changes → `src/components/Editor/Editor.tsx`
+  - UI primitives → `src/components/UI/`
+  - Sidebar / files list → `src/components/Layouts/MainLayout/FilesPanel/`
+- One sentence on what *not* in scope (so scope creep is easier to push back on later).
+
+## 6. Wait for the user's next instruction
+
+Don't start making code changes yet. The user may want to plan, ask questions, or split the work across multiple sessions.
+
+## Don'ts
+
+- Don't auto-pull main. The user may have uncommitted commits to merge first.
+- Don't auto-stash dirty changes.
+- Don't create a branch off anything other than main without asking.
+- Don't push the branch to remote — `committer` will, on first commit, if you set upstream then.
+- Don't make code changes in this skill — just set up.

--- a/.claude/skills/ui-component-creator/SKILL.md
+++ b/.claude/skills/ui-component-creator/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: ui-component-creator
+description: Use when the user wants a new reusable UI primitive under `src/components/UI/` — Button, Input, Modal, Textarea, Card, Badge, Tooltip, etc. Also use when extracting feature-local markup into a shared UI primitive. Triggers on phrases like "add a Textarea component", "create a Modal UI primitive", "extract this into a shared UI component". Enforces the pattern documented in `src/components/UI/CLAUDE.md` and `.claude/rules/ui-components.md`.
+---
+
+# UI component creator
+
+You're creating (or refactoring) a reusable UI primitive. The pattern is non-negotiable — Lumark's UI primitives compose because they all look the same.
+
+## Read the authoritative sources first
+
+- `src/components/UI/CLAUDE.md` — full pattern, scoped to this folder.
+- `.claude/rules/ui-components.md` — mirrored standalone reference.
+- `src/components/UI/Button/Button.tsx` + `Button/types.ts` — canonical reference (component with children).
+- `src/components/UI/Input/Input.tsx` + `Input/types.ts` — canonical reference (no children, spreads onto a wrapped element).
+
+## Decide first: does this belong in UI?
+
+- **Yes**: reusable presentational primitive with UI sense beyond any one feature (button, input, modal, card, badge, tooltip).
+- **No**: feature-specific markup (a file row, the editor toolbar). Keep it next to the feature.
+
+If unsure, ask the user.
+
+## Scaffold
+
+Create exactly two files:
+
+```
+src/components/UI/<Name>/<Name>.tsx
+src/components/UI/<Name>/types.ts
+```
+
+### `types.ts` template
+
+```ts
+import { <RootHTMLAttributes>, PropsWithChildren, ReactNode } from 'react';
+
+export type <Name>SizeType = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type <Name>VariantType = 'primary' | 'secondary' | /* ... */;
+export type <Name>RoundedType = 'default' | 'rounded';
+
+export interface I<Name>Props
+  extends <PropsWithChildren,>  // only if renders children
+          <RootHTMLAttributes><HTMLElement> {
+  size?: <Name>SizeType;
+  variant?: <Name>VariantType;
+  rounded?: <Name>RoundedType;
+  // ... per-element className props (see below)
+}
+```
+
+### `<Name>.tsx` skeleton
+
+```tsx
+import { FC, useMemo } from 'react';
+import { I<Name>Props, <Name>SizeType, <Name>VariantType, <Name>RoundedType } from './types';
+
+const <Name>: FC<I<Name>Props> = ({
+  // destructure your own named props with sensible defaults
+  size = 'md',
+  variant = 'primary',
+  rounded = 'default',
+  wrapperClassName = '',
+  className = '',
+  ...props
+}) => {
+  const elSize = useMemo(() => {
+    const sizeMapping: Record<<Name>SizeType, string> = {
+      xs: '...', sm: '...', md: '...', lg: '...', xl: '...',
+    };
+    return sizeMapping[size] || sizeMapping.md;
+  }, [size]);
+
+  // ... other useMemo'd variant mappings
+
+  return (
+    <div className={`${wrapperClassName}`}>
+      <element
+        className={`${elSize} ${className}`}
+        {...props}
+      />
+    </div>
+  );
+};
+
+export default <Name>;
+```
+
+## Rules (non-negotiable)
+
+1. **`I<Name>Props` extends the native HTML attributes of the root element**:
+   - `<button>` → `ButtonHTMLAttributes<HTMLButtonElement>`
+   - `<input>` → `InputHTMLAttributes<HTMLInputElement>`
+   - `<textarea>` → `TextareaHTMLAttributes<HTMLTextAreaElement>`
+   - `<a>` → `AnchorHTMLAttributes<HTMLAnchorElement>`
+   - plain `<div>` wrapper → `HTMLAttributes<HTMLDivElement>`
+2. **Also extend `PropsWithChildren` only when the component renders children.** Button yes, Input no.
+3. **`{...props}` placement**: onto the root element by default, **or** onto the most semantically important element when the component wraps its root. `Input` spreads onto its inner `<input>` because that's what callers configure.
+4. **Multiple `*ClassName` props** for flexibility — one per meaningful structural layer. Names follow the structural role: `wrapperClassName`, `labelClassName`, `buttonContainerClassName`, `buttonContentClassName`, `textareaClassName`. The plain destructured `className` is reserved for the root/most-important element.
+5. **Variant props are string-literal unions** mapped via `Record<UnionType, string>` inside `useMemo` with a sensible default fallback. Never sprinkle ternaries inline.
+6. **Inline Tailwind utility classes only.** No CSS modules, styled-components, CSS-in-JS, or external UI libs.
+7. **Use theme tokens from `src/assets/css/`**: `bg-surface`, `text-text-color`, `border-border-color`, `bg-primary` (+ `-hover` / `-active`), `bg-danger`, `bg-success`, `bg-warning`, `bg-info`, `bg-secondary`, `text-danger`. Don't hardcode hex colors.
+8. **Icons**: use `lucide-react` (already a dep). Don't import `react-icons` or other icon libs.
+9. **No tests, no stories, no emojis** in component code.
+
+## Verification
+
+After writing, run `yarn lint` from the repo root and fix any errors before reporting back.
+
+## Delegation
+
+For non-trivial components, consider delegating to the `ui-component-author` subagent (`.claude/agents/ui-component-author.md`) which has the same context in a separate window.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Claude
+.claude/settings.local.json
+.mcp.json

--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Lumark is a local-first cross-platform Markdown note-taking desktop app built with **Tauri 2** (Rust backend) + **React 19 + TypeScript + Vite** (frontend). It uses **Yarn** as the package manager.
+
+## Commands
+
+```bash
+yarn tauri dev      # run the full desktop app (Tauri + Vite, port 1420)
+yarn dev            # Vite-only dev server (browser preview — most Tauri features won't work)
+yarn build          # tsc type-check + vite production build into dist/
+yarn tauri build    # produce distributable installers for the current OS
+yarn lint           # ESLint flat config (eslint.config.mjs)
+yarn lint:fix       # ESLint with --fix
+```
+
+No test runner is configured.
+
+The Tauri dev port `1420` is `strictPort: true` — a stale process holding the port will fail the dev server.
+
+## Architecture
+
+### Two-process model
+- **Frontend** (`src/`) — React UI that never touches the filesystem directly.
+- **Rust backend** (`src-tauri/src/lib.rs`) — defines all `#[tauri::command]` functions and is the *only* place file I/O happens.
+- Communication is exclusively via `invoke('command_name', args)` from `@tauri-apps/api/core`.
+
+When adding any feature that reads/writes user data, you must (1) add a `#[tauri::command]` in `src-tauri/src/lib.rs`, (2) register it in the `invoke_handler!` macro at the bottom of that file, and (3) call it from the frontend via `invoke(...)`.
+
+### File storage model
+All notes are flat `.md` files inside Tauri's `app_data_dir()` (resolved per-OS by `app.path().app_data_dir()`).
+
+A critical convention: **the frontend identifies files by their base name without the `.md` extension**. The Rust commands do `file_name + ".md"` themselves (see `load_content_by_name`, `save_content_by_name`, `add_file`, `delete_file_by_name`). Do not pass an already-extended name from JS — it will produce `foo.md.md`. `load_files` returns names via `path.file_stem()`, also extension-stripped.
+
+### Global state
+There is one React context: `src/contexts/AppProvider.tsx`. It owns the *entire* app state:
+- `content` / `setContent` — the current editor buffer
+- `editorMode` (`SPLIT` | `EDIT` | `PREVIEW` from `editorEnums.ts`)
+- `files` — the file list loaded from Rust
+- `selectedFile` — the currently open file's base name
+- async ops: `fetchFiles`, `selectFile`, `deleteFile`
+
+Consume via `useAppContext()`. There is no Redux/Zustand/etc.
+
+The provider runs three effects that wire the data flow:
+1. On mount → `fetchFiles()`.
+2. When `selectedFile` changes → `invoke('load_content_by_name')` and set `content`.
+3. When `content` or `selectedFile` changes → **debounced 500 ms autosave** via `invoke('save_content_by_name')`. There is no explicit save action; every keystroke debounces a write.
+
+Be careful when introducing new effects that touch `content` — they can race with the autosave debounce or with the initial-load effect.
+
+### Editor component
+`src/components/Editor/Editor.tsx` runs two parallel views from the same `content` string:
+- **Edit pane**: a CodeMirror 6 `EditorView` constructed imperatively against `#editor-container`. The constructor effect has an empty dep array so the editor is created once; an `isEditorContentSetInitially` flag is used to push `content` into CodeMirror only on the initial mount per selected file, and is reset whenever `selectedFile` changes. Updates flow back via the `updateListener` calling `setContent`.
+- **Preview pane**: `react-markdown` with `remark-gfm` + `rehype-raw` + `rehype-highlight`, styled by `github-markdown-css` and `highlight.js/styles/github.css`.
+
+The two panes are shown/hidden via Tailwind classes driven by `editorMode`; both remain mounted in `SPLIT` mode.
+
+### Layout
+`MainLayout` is a fixed two-column shell: sidebar `FilesPanel` (`src/components/Layouts/MainLayout/FilesPanel/`) on the left, editor children on the right. There is no router.
+
+### UI components (`src/components/UI/`)
+This folder is a small in-house UI library. When rendering a generic UI element (button, input, modal, textarea, card, etc.), **first check `src/components/UI/` and reuse what exists**. Don't reach for an external UI library.
+
+If the element you need has a generic UI sense (i.e. it's a reusable presentational primitive, not feature-specific markup) and it doesn't exist yet, **create it in `src/components/UI/` following the existing pattern**. Use feature-local markup directly only when the piece has no reusable UI sense.
+
+Pattern to follow exactly (see `src/components/UI/Button/`, `src/components/UI/Input/` as references):
+
+1. **Folder + file structure**: `src/components/UI/<Name>/<Name>.tsx` + `src/components/UI/<Name>/types.ts`. One folder per component.
+2. **Types live in `types.ts`**. Export a props interface named `I<Name>Props` plus any string-literal union types the component exposes (e.g. `ButtonSizeType`, `InputRoundedType`).
+3. **Props interface extends the native attributes of the root element** so consumers get the full HTML API for free:
+   - `<button>` → `extends ButtonHTMLAttributes<HTMLButtonElement>`
+   - `<input>` → `extends InputHTMLAttributes<HTMLInputElement>`
+   - `<textarea>` → `extends TextareaHTMLAttributes<HTMLTextAreaElement>`
+   - plain `<div>` → `extends HTMLAttributes<HTMLDivElement>`, etc.
+4. **If the component accepts children**, the props interface should **also extend `PropsWithChildren`** (see `IButtonProps`). If it does not (e.g. `<input>`), do not.
+5. **Component is typed `FC<I<Name>Props>`** and destructures its own named props, leaving `...props` (or `...rest`) to spread onto the root element. `{...props}` goes on the **root element by default**, or on the **most important element when the component wraps its root** — e.g. `Input` spreads onto the actual `<input>` inside a wrapper `<div>`, because the `<input>` is the semantically important element.
+6. **Be liberal with `*ClassName` props for flexibility**. Expose a separate className prop for each meaningful structural element rather than only one. Naming follows the structural role: `wrapperClassName`, `labelClassName`, `buttonContainerClassName`, `buttonContentClassName`, `textareaClassName`, etc. The plain destructured `className` is reserved for the root/most-important element so it composes naturally with `{...props}`.
+7. **Variant props use string-literal union types** mapped to Tailwind class strings via a `Record<UnionType, string>` inside `useMemo`, with a sensible default fallback (see how `Button` handles `size`, `variant`, `rounded`).
+8. Styling is Tailwind utility classes inline in the component — do not introduce CSS modules or styled-components for UI primitives.
+
+### Styling
+Tailwind v4 via `@tailwindcss/vite` (no separate `tailwind.config.js` v3-style content scanning needed at runtime). Custom CSS variables for theme tokens like `bg-surface`, `text-text-color`, `border-border-color` are defined in `src/assets/css/`.
+
+## Conventions observed in this repo
+
+- **Branches & commits**: branches are created from a GitHub issue ("Create a branch" button), and commit messages follow `<type>(<issue#>): <subject>` — e.g. `feat(47): ...`, `fix(47): ...`, `chore(47): ...`. PRs target `main`.
+- **Versioning**: the app version lives in `src-tauri/tauri.conf.json` (not `package.json`, which is still `0.1.0`). Bump it there when shipping a release.
+- **ESLint flat config**: 2-space indent, single quotes (JSX double), required semicolons, trailing commas on multiline, arrow `as-needed` body style. Run `yarn lint:fix` before committing.
+- **No new test framework**: don't add Jest/Vitest configuration as part of unrelated tasks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,34 @@ No test runner is configured.
 
 The Tauri dev port `1420` is `strictPort: true` — a stale process holding the port will fail the dev server.
 
+## First-time setup: MCP (`.mcp.json`)
+
+`.mcp.json` is **gitignored** so each contributor can add their own API keys without leaking secrets. The committed template is `.mcp.example.json`.
+
+On a fresh clone, copy the template:
+
+```bash
+cp .mcp.example.json .mcp.json
+```
+
+That's enough to get Context7 working at the free tier — the hosted endpoint (`https://mcp.context7.com/mcp`) requires no auth for basic usage. If you have a Context7 API key, add an `Authorization` header inside `.mcp.json` (not the example — never commit secrets):
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": { "Authorization": "Bearer <YOUR_KEY>" }
+    }
+  }
+}
+```
+
+The repo's committed `.claude/settings.json` already pre-approves the `context7` server via `enabledMcpjsonServers`, so Claude Code won't prompt to enable it once `.mcp.json` exists locally.
+
+If `.mcp.json` is missing, the `docs-explorer` skill and the `mcp__context7__*` tools won't be available — the skill flags this and falls back to a personal claude.ai Context7 connection if you have one.
+
 ## Architecture
 
 ### Two-process model
@@ -84,6 +112,40 @@ Pattern to follow exactly (see `src/components/UI/Button/`, `src/components/UI/I
 
 ### Styling
 Tailwind v4 via `@tailwindcss/vite` (no separate `tailwind.config.js` v3-style content scanning needed at runtime). Custom CSS variables for theme tokens like `bg-surface`, `text-text-color`, `border-border-color` are defined in `src/assets/css/`.
+
+## Folder-scoped rules
+
+Nested `CLAUDE.md` files layer additional rules that apply when working inside those folders:
+
+- `src-tauri/CLAUDE.md` — Rust/Tauri backend: command shape, the three-step IPC contract, file-extension contract, naming conventions.
+- `src/contexts/CLAUDE.md` — global state and effect-ordering invariants in `AppProvider`.
+- `src/components/Editor/CLAUDE.md` — CodeMirror lifecycle invariants and the React↔CodeMirror sync pattern.
+- `src/components/UI/CLAUDE.md` — full pattern for in-house UI primitives.
+
+These are auto-loaded by Claude Code when working in those subtrees — you don't need to import them.
+
+## Project skills (`.claude/skills/`)
+
+Skills auto-trigger when a task matches their description. Available in this repo:
+
+- `committer` — drafts commits in the `<type>(<issue#>): <subject>` format, deriving the issue number from the branch name.
+- `ipc-command-creator` — adds a new Tauri `#[tauri::command]` end-to-end (Rust fn + `invoke_handler!` registration + frontend wiring).
+- `ipc-command-invoker` — calls an *existing* Tauri command from a new place in the frontend (no Rust changes).
+- `ui-component-creator` — scaffolds a new UI primitive under `src/components/UI/` following the Button/Input pattern.
+- `docs-explorer` — answers library/framework/API questions by consulting Context7 (`mcp__context7__*` from the project `.mcp.json`) — used for React 19, Tauri 2, CodeMirror 6, Tailwind 4, etc.
+- `eslint-fixer` — runs `yarn lint`, applies safe `--fix`, hand-fixes the remainder respecting the empty-dep-array invariants in `AppProvider.tsx` and `Editor.tsx`.
+- `issue-starter` — given a GitHub issue number, runs `gh issue view`, creates the branch in `<issue#>-<kebab-summary>` form, and summarises the scope (CONTRIBUTING.md steps 1–3).
+- `codemirror-extension-adder` — adds CodeMirror 6 extensions to the editor following the static-vs-reactive (`Compartment`) decision and the lifecycle invariants in `src/components/Editor/CLAUDE.md`.
+
+## Rule catalog (reference only — not auto-loaded)
+
+`.claude/rules/` is a human-browsable catalog. **Claude Code does not auto-load anything from this folder** — only `CLAUDE.md` files auto-load. The catalog exists so a person (or a conversation pointing at `@.claude/rules/<name>.md`) can read the rules in one place. Cross-cutting rules that don't fit any single folder live there:
+
+- `.claude/rules/ipc.md` — frontend ↔ Rust IPC contract end-to-end
+- `.claude/rules/commits-and-branches.md` — git workflow, commit-message format
+- `.claude/rules/code-style.md` — ESLint highlights, file naming, the versioning quirk, "no test runner"
+
+The folder-scoped rules (UI, Editor, contexts, src-tauri) are also mirrored there, but the **nested `CLAUDE.md` files above are authoritative** — those are what Claude Code actually loads. See `.claude/rules/README.md` for the full index and authority rules.
 
 ## Conventions observed in this repo
 

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -1,0 +1,69 @@
+# Rust / Tauri backend — rules
+
+This crate is the **only** place in the project that touches the filesystem or any other host capability. The React frontend reaches it exclusively via `invoke('command_name', args)`.
+
+## Where things go
+
+- All `#[tauri::command]` functions live in `src/lib.rs`. Don't split them across new modules without a real reason — the file is still small.
+- `main.rs` is just the binary entry — it calls into `lib.rs`.
+- New Tauri plugins are added to `Cargo.toml` and initialised inside `run()` (see `tauri_plugin_opener::init()` for the existing pattern).
+- Native config (window title/size, bundle targets, identifier) lives in `tauri.conf.json`.
+
+## Command shape (match the existing functions)
+
+Every IPC command must look like the ones already in `lib.rs`:
+
+```rust
+#[tauri::command]
+fn <snake_case_name>(app: AppHandle, <named_args>) -> Result<T, String> {
+    use std::fs;
+
+    let app_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+
+    // ... work ...
+
+    Ok(value)
+}
+```
+
+- Take `app: AppHandle` first when you need the data dir.
+- Return `Result<T, String>` and map every `io::Error` to a descriptive `String` via `.map_err(|e| format!(...))`. Don't unwrap.
+- Use `app.path().app_data_dir()` — never an absolute path or `std::env::current_dir()`.
+- `use std::fs;` inside the function (matches the existing style — no top-of-file `use`).
+
+## The three-step contract (forgetting any of these is the most common bug)
+
+1. Write the `#[tauri::command]` fn.
+2. **Register it** in the `invoke_handler![...]` macro list at the bottom of `lib.rs`. If you skip this, the frontend call fails at runtime with "command not found" — the compiler will *not* catch it.
+3. Wire the frontend caller — usually through `src/contexts/AppProvider.tsx` if it touches shared state.
+
+## Naming conventions
+
+- Rust parameter names: `snake_case` (e.g. `file_name`).
+- Frontend `invoke` argument keys: `camelCase` (e.g. `fileName`). Tauri auto-converts. Don't pass `file_name` from JS.
+- Command names: `snake_case` (e.g. `delete_file_by_name`).
+
+## File naming convention (extension contract)
+
+The frontend identifies files by their **base name without the `.md` extension**. The Rust side appends it:
+
+```rust
+let file_path = app_dir.join(file_name + ".md");
+```
+
+`load_files` returns base names via `path.file_stem()`. Do not break this contract — passing an already-extended name from JS produces `foo.md.md`.
+
+## Don'ts
+
+- Don't introduce file I/O in the frontend; it belongs here.
+- Don't `.unwrap()` on `io::Result` — map to `String`.
+- Don't change the file extension contract without updating every command and every frontend caller in the same change.
+- Don't add async commands unless they actually need to be async — none currently are.
+- Don't pull in `serde_yaml`, `tokio`, etc., without a real need; current deps are intentionally minimal.
+
+## Verification
+
+After changes, run `cargo check --manifest-path src-tauri/Cargo.toml` from the repo root. `cargo clippy` is optional but welcome.

--- a/src/components/Editor/CLAUDE.md
+++ b/src/components/Editor/CLAUDE.md
@@ -1,0 +1,33 @@
+# Editor — rules
+
+The editor mounts **CodeMirror 6 imperatively** alongside a **react-markdown** preview, both driven by the same `content` string from `AppContext`. The lifecycle has a few invariants that are easy to break.
+
+## Invariants you must preserve
+
+1. **CodeMirror is constructed once.** The construction effect in `Editor.tsx` has an empty dep array intentionally. Do not add deps to it — recreating the `EditorView` on every render leaks DOM and destroys cursor state.
+2. **The `#editor-container` DOM node is the mount point.** It's a single `<div>` and CodeMirror appends into it. Don't conditionally unmount the wrapper based on `editorMode` — visibility is controlled via Tailwind `hidden`, not unmount, so the CodeMirror instance survives mode switches.
+3. **`isEditorContentSetInitially` gates the initial doc push** from React `content` → CodeMirror. It's reset to `false` whenever `selectedFile` changes so the new file's content is pushed once, then ongoing edits flow back through the `updateListener` without ping-ponging.
+4. **Updates back into React happen via the `updateListener.of(...)` extension**, calling `setContent(update.state.doc.toString())`. Don't introduce a parallel React-side sync — you'll get an autosave/reload loop.
+5. **Both panes stay mounted in `SPLIT` mode**; `EDIT` and `PREVIEW` modes hide the other half via Tailwind `hidden` + `!w-full`. Don't replace this with conditional rendering — see invariant 2.
+
+## Adding CodeMirror extensions
+
+- Append to the `extensions: [...]` array in the construction effect.
+- If the extension needs to react to changing React props (e.g. theme toggle), use a [`Compartment`](https://codemirror.net/docs/ref/#state.Compartment) and `editorRef.current.dispatch({ effects: compartment.reconfigure(...) })`. Do *not* add the prop to the construction effect's dep array.
+- New language support → import from `@codemirror/lang-*`. The current setup only loads `markdown()`.
+
+## Preview pane
+
+- Renders through `<ReactMarkdown>` with `remark-gfm`, `rehype-raw`, `rehype-highlight`.
+- Styling comes from `github-markdown-css` (light variant currently hard-coded) and `highlight.js/styles/github.css`. The light-theme imports are noted in inline comments as future-dark-mode targets — don't rip them out without a dark-mode story.
+- If you add a new remark/rehype plugin, add it to the appropriate array — don't introduce a custom markdown pipeline.
+
+## EditorMode
+
+`EditorMode.tsx` is the mode-switcher UI. It writes to `editorMode` via `handleEditorModeChange` from `AppContext`. New modes start by adding a value to `EditorModeEnum` in `src/types/editor/editorEnums.ts`, then both this component and the visibility classes in `Editor.tsx`.
+
+## Don'ts
+
+- Don't swap CodeMirror for `react-simple-code-editor` or similar — the in-code TODO comment mentioning it is exploratory, not a decision.
+- Don't add a debounce in `Editor.tsx` — autosave is already debounced in `AppProvider`. A second debounce would compound the delay.
+- Don't read the editor's value from `editorRef.current.state.doc.toString()` for anything except the existing comparison in the initial-push effect; the React `content` state is the source of truth everywhere else.

--- a/src/components/UI/CLAUDE.md
+++ b/src/components/UI/CLAUDE.md
@@ -1,0 +1,45 @@
+# UI primitives — rules
+
+This folder is Lumark's in-house UI library. Every component in here must follow the same shape so they compose predictably.
+
+## When to add a component here
+
+- **Yes**: the element is a reusable presentational primitive (button, input, modal, textarea, card, badge, tooltip, etc.). It has UI sense outside any one feature.
+- **No**: the markup is feature-specific (a file row, the editor toolbar, a sidebar header) — keep it next to the feature.
+
+Before writing new markup elsewhere, scan this folder first and reuse what exists. If a primitive is *missing*, add it here rather than reaching for an external UI library.
+
+## The pattern (non-negotiable)
+
+References: `Button/Button.tsx` + `Button/types.ts`, `Input/Input.tsx` + `Input/types.ts`. Match them.
+
+1. **File layout**: `<Name>/<Name>.tsx` + `<Name>/types.ts`. One folder per component. `export default` the component.
+2. **`types.ts`** exports:
+   - `I<Name>Props` (capital `I` prefix).
+   - String-literal union types the component exposes — `<Name>SizeType`, `<Name>VariantType`, `<Name>RoundedType`, `<Name>IconPositionType`, etc.
+3. **`I<Name>Props` extends the native HTML attributes of the root element**:
+   - `<button>` → `ButtonHTMLAttributes<HTMLButtonElement>`
+   - `<input>` → `InputHTMLAttributes<HTMLInputElement>`
+   - `<textarea>` → `TextareaHTMLAttributes<HTMLTextAreaElement>`
+   - `<a>` → `AnchorHTMLAttributes<HTMLAnchorElement>`
+   - plain `<div>` wrapper → `HTMLAttributes<HTMLDivElement>`
+4. **Also extend `PropsWithChildren` only when the component renders children**. `Button` does; `Input` does not.
+5. **Component is `FC<I<Name>Props>`**. Destructure your own named props, leave `...props` (or `...rest`) for spreading.
+6. **Where `{...props}` goes**: onto the **root element by default**, or onto the **most semantically important element when the component wraps its root**. `Input` spreads onto the `<input>` inside its wrapper `<div>` because `<input>` is what callers actually configure (`value`, `onChange`, `placeholder`, `type`...).
+7. **Multiple `*ClassName` props** for flexibility — one per meaningful structural layer, named for its role: `wrapperClassName`, `labelClassName`, `buttonContainerClassName`, `buttonContentClassName`, `textareaClassName`, `iconWrapperClassName`. The plain destructured `className` is reserved for the root/most-important element so it composes with `{...props}`.
+8. **Variant props are string-literal unions** mapped through a `Record<UnionType, string>` inside `useMemo`, with a fallback to a sensible default:
+   ```ts
+   const buttonSize = useMemo(() => {
+     const sizeMapping: Record<ButtonSizeType, string> = { xs: '...', sm: '...', md: '...' };
+     return sizeMapping[size] || sizeMapping.md;
+   }, [size]);
+   ```
+9. **Styling is inline Tailwind utility classes**. No CSS modules, no styled-components, no CSS-in-JS, no external UI libs.
+10. **Theme tokens**: use the custom Tailwind variables defined in `src/assets/css/` — `bg-surface`, `text-text-color`, `border-border-color`, `bg-primary` (+ `-hover`/`-active` variants), `bg-danger`, `bg-success`, `bg-warning`, `bg-info`, `bg-secondary`, `text-danger`, etc. Don't hardcode hex colors.
+
+## Don'ts
+
+- Don't import from `react-icons` or large icon libraries — the project uses `lucide-react`.
+- Don't add `forwardRef` unless a consumer actually needs the ref (none currently do).
+- Don't add a story/test file — there's no Storybook or test runner in this repo.
+- Don't put any emojis in component code.

--- a/src/contexts/CLAUDE.md
+++ b/src/contexts/CLAUDE.md
@@ -1,0 +1,39 @@
+# Global state — rules
+
+This folder owns the **entire** app's shared state. There is currently one provider — `AppProvider.tsx` — and that's intentional. No Redux, Zustand, Jotai, or similar.
+
+## How to add shared state
+
+1. Add the state slice and any setters/handlers inside `AppProvider`.
+2. Extend the `IAppContext` interface with the new field.
+3. Surface it through the `value` object passed to `<AppContext.Provider>`.
+4. Consumers read it via `useAppContext()` — never by importing `AppContext` directly.
+
+If a piece of state is local to one component or one subtree, **keep it there with `useState`/`useReducer`** rather than promoting it to the context. Only promote to the context when more than one unrelated part of the UI needs it.
+
+## Effect ordering — handle with care
+
+`AppProvider` runs three effects that wire together selection → load → autosave:
+
+1. On mount → `fetchFiles()` populates `files`.
+2. When `selectedFile` changes → `invoke('load_content_by_name')` and `setContent(...)`.
+3. When `content` *or* `selectedFile` changes → **debounced 500 ms autosave** via `invoke('save_content_by_name')`.
+
+When adding effects that read or write `content`, watch out for:
+
+- **Autosave races**: any new write to `content` re-triggers the autosave timer. If you `setContent('')` (e.g. after deleting the open file), make sure `selectedFile` is cleared in the same update so autosave doesn't persist the empty buffer back into a still-selected file. See `deleteFile` for the existing pattern.
+- **Initial-load races**: the load effect overwrites `content` whenever `selectedFile` changes. Don't start derived effects that depend on `content` being "ready" — there is no ready signal beyond `selectedFile` being set.
+- **No explicit save action**: every keystroke schedules a write. Don't introduce a "Save" button unless you also gate the autosave behind it.
+
+## Tauri IPC conventions
+
+- Always go through `invoke('command_name', { argInCamelCase })` from `@tauri-apps/api/core`. The Rust side names parameters in `snake_case`; Tauri converts.
+- Always `await invoke(...)` inside a `try/catch` and log via `console.error` on failure (matches the existing style; ESLint has `no-console: 'warn'` so prefer `error`/`warn` over `log`).
+- After any IPC that mutates the files list (create, rename, delete), call `await fetchFiles()` to refresh — the Rust side does not push updates.
+
+## Don'ts
+
+- Don't add a second context for ad-hoc state — extend this one.
+- Don't read files directly from the frontend; everything goes through `invoke`.
+- Don't pass `.md`-suffixed names across IPC — see `src-tauri/CLAUDE.md`.
+- Don't replace the debounce with a different pattern without considering existing edit-→autosave-→reload races.


### PR DESCRIPTION
closes #51 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up a complete Claude Code framework with auto-loaded guidance, skills, agents, and slash commands to streamline work on Tauri IPC, UI components, the editor, linting, and commits. Addresses #51 by adding path-scoped rules, a rules catalog, and Context7 MCP integration for up-to-date docs.

- New Features
  - Added root and folder-scoped `CLAUDE.md` (repo, `src-tauri`, `src/contexts`, `src/components/Editor`, `src/components/UI`) with authoritative rules.
  - Introduced skills (`.claude/skills/`): committer, IPC command creator/invoker, UI component creator, CodeMirror extension adder, ESLint fixer, docs explorer (Context7), and issue starter.
  - Added agents (`.claude/agents/`): `tauri-command-author` and `ui-component-author`.
  - Added slash commands (`.claude/commands/`): `new-ui`, `new-tauri-cmd`, `check`, `bump-version`.
  - Created rules catalog (`.claude/rules/*`) for human reference; nested `CLAUDE.md` remains the source of truth.
  - Added `.claude/settings.json` enabling `context7` MCP and safe `Bash`/`git` actions; added `.mcp.example.json`; updated `.gitignore`.
  - No runtime app logic changed.

- Migration
  - To enable Context7 tools locally, copy `.mcp.example.json` to `.mcp.json` (optionally add an auth header). No other steps required.

<sup>Written for commit 0796ba3f07388e3faf2eacc5580c99975852bfa4. Summary will update on new commits. <a href="https://cubic.dev/pr/AlbertArakelyan/Lumark/pull/52?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

