### PR TITLE
55 linux tauriwebkit runtime files hsts storagemd hsts storagesqlite cookies appear inside the notes directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 # Claude
 .claude/settings.local.json
 .mcp.json
+claude-latest-session.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,9 @@ If `.mcp.json` is missing, the `docs-explorer` skill and the `mcp__context7__*` 
 When adding any feature that reads/writes user data, you must (1) add a `#[tauri::command]` in `src-tauri/src/lib.rs`, (2) register it in the `invoke_handler!` macro at the bottom of that file, and (3) call it from the frontend via `invoke(...)`.
 
 ### File storage model
-All notes are flat `.md` files inside Tauri's `app_data_dir()` (resolved per-OS by `app.path().app_data_dir()`).
+All notes are flat `.md` files inside a `notes/` subdirectory of Tauri's `app_data_dir()` (resolved per-OS by `app.path().app_data_dir()`). The subdirectory exists so notes don't sit next to WebKit-managed files (`hsts-storage.*`, `cookies.*`) that Tauri writes into `app_data_dir` on Linux. The Rust side resolves it through a `notes_dir(&app)` helper in `src-tauri/src/lib.rs` that creates the dir on demand; commands must use that helper rather than joining straight onto `app_data_dir()`.
+
+A startup migration (`migrate_notes_to_subdir`) moves any pre-existing top-level `*.md` files into `notes/` once, skipping `hsts-storage.md` and any name that would overwrite an existing target.
 
 A critical convention: **the frontend identifies files by their base name without the `.md` extension**. The Rust commands do `file_name + ".md"` themselves (see `load_content_by_name`, `save_content_by_name`, `add_file`, `delete_file_by_name`). Do not pass an already-extended name from JS — it will produce `foo.md.md`. `load_files` returns names via `path.file_stem()`, also extension-stripped.
 

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -139,19 +139,21 @@ There is **no test runner configured** (no Jest/Vitest/Playwright). Do not add o
 
 ### File storage
 
-Notes are flat `.md` files inside Tauri's `app_data_dir()` (resolved per-OS by `app.path().app_data_dir()`).
+Notes are flat `.md` files inside a `notes/` subdirectory of Tauri's `app_data_dir()` (resolved per-OS by `app.path().app_data_dir()`).
 
 Bundle identifier: `com.albertarakelyan.lumark` (set in `src-tauri/tauri.conf.json`). Tauri resolves `app_data_dir()` to:
 
 | OS | Path |
 | --- | --- |
-| Linux | `$XDG_DATA_HOME/com.albertarakelyan.lumark/` or `$HOME/.local/share/com.albertarakelyan.lumark/` |
-| macOS | `$HOME/Library/Application Support/com.albertarakelyan.lumark/` |
-| Windows | `%APPDATA%\com.albertarakelyan.lumark\` (typically `C:\Users\<User>\AppData\Roaming\com.albertarakelyan.lumark\`) |
+| Linux | `$XDG_DATA_HOME/com.albertarakelyan.lumark/notes/` or `$HOME/.local/share/com.albertarakelyan.lumark/notes/` |
+| macOS | `$HOME/Library/Application Support/com.albertarakelyan.lumark/notes/` |
+| Windows | `%APPDATA%\com.albertarakelyan.lumark\notes\` (typically `C:\Users\<User>\AppData\Roaming\com.albertarakelyan.lumark\notes\`) |
 
 This is also where you can inspect or back up the user's notes during development.
 
-**Extension contract**: the frontend identifies files by their **base name without the `.md` extension**. The Rust side appends it (`app_dir.join(file_name + ".md")`). Passing an already-extended name from JS produces `foo.md.md`. `load_files` returns names via `path.file_stem()`.
+Why the `notes/` subdirectory: on Linux the parent `app_data_dir` is shared with WebKitGTK, which writes runtime files (`hsts-storage.md`, `hsts-storage.sqlite`, `cookies.*`) directly into it. Keeping notes one level down isolates them from WebKit state. A startup migration in `src-tauri/src/lib.rs` (`migrate_notes_to_subdir`) moves any pre-existing top-level `*.md` files into `notes/` once — `hsts-storage.md` is explicitly skipped because WebKit recreates it.
+
+**Extension contract**: the frontend identifies files by their **base name without the `.md` extension**. The Rust side appends it (`notes_dir.join(file_name + ".md")`). Passing an already-extended name from JS produces `foo.md.md`. `load_files` returns names via `path.file_stem()`.
 
 ### Global state
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,9 +1,83 @@
+use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 
 #[derive(serde::Serialize)]
 struct FileInfo {
     file_name: String,
     date_created: String,
+}
+
+// Resolve (and create) the dedicated notes directory inside app_data_dir.
+// Notes are kept here so they don't sit next to WebKit-managed files
+// (hsts-storage.*, cookies.*) that Tauri writes into app_data_dir on Linux.
+fn notes_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    use std::fs;
+
+    let app_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+
+    let notes = app_dir.join("notes");
+    fs::create_dir_all(&notes)
+        .map_err(|e| format!("Failed to create notes dir: {}", e))?;
+
+    Ok(notes)
+}
+
+// One-time migration: move every *.md file from the top of app_data_dir
+// into app_data_dir/notes/. Skips WebKit-managed files and skips any name
+// that would overwrite an existing file in notes/.
+fn migrate_notes_to_subdir(app: &AppHandle) -> Result<(), String> {
+    use std::fs;
+
+    // WebKit/Tauri runtime files that must not be migrated as user notes.
+    // hsts-storage.md is recreated by WebKitGTK at the app_data_dir root on Linux.
+    const WEBKIT_FILES: &[&str] = &["hsts-storage.md"];
+
+    let app_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+
+    if !app_dir.exists() {
+        return Ok(());
+    }
+
+    let notes = notes_dir(app)?;
+
+    for entry in fs::read_dir(&app_dir)
+        .map_err(|e| format!("Failed to read app data dir: {}", e))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+        let path = entry.path();
+
+        if !path.is_file() {
+            continue;
+        }
+
+        let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+
+        if !file_name.ends_with(".md") {
+            continue;
+        }
+
+        if WEBKIT_FILES.contains(&file_name) {
+            continue;
+        }
+
+        let dest = notes.join(file_name);
+        if dest.exists() {
+            continue;
+        }
+
+        fs::rename(&path, &dest)
+            .map_err(|e| format!("Failed to migrate {} into notes/: {}", file_name, e))?;
+    }
+
+    Ok(())
 }
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
@@ -16,16 +90,8 @@ fn greet(name: &str) -> String {
 fn save_content(app: AppHandle, content: String) -> Result<(), String> {
     use std::fs;
 
-    let app_dir = app
-        .path()
-        .app_data_dir()
-        .expect("failed to retrieve app data dir");
-
-    // Ensure the directory exists
-    fs::create_dir_all(&app_dir)
-        .map_err(|e| format!("Failed to create app data dir: {}", e))?;
-
-    let file_path = app_dir.join("content.md");
+    let notes = notes_dir(&app)?;
+    let file_path = notes.join("content.md");
 
     fs::write(&file_path, content)
         .map_err(|e| format!("Failed to write content file: {}", e))?;
@@ -37,19 +103,15 @@ fn save_content(app: AppHandle, content: String) -> Result<(), String> {
 fn load_content(app: AppHandle) -> Result<String, String> {
     use std::fs;
 
-    let app_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
-
-    let file_path = app_dir.join("content.md");
+    let notes = notes_dir(&app)?;
+    let file_path = notes.join("content.md");
 
     if file_path.exists() {
         let content = fs::read_to_string(&file_path)
             .map_err(|e| format!("Failed to read content file: {}", e))?;
         Ok(content)
     } else {
-        Ok(String::new()) // Return empty string if file doesn't exist
+        Ok(String::new())
     }
 }
 
@@ -57,19 +119,15 @@ fn load_content(app: AppHandle) -> Result<String, String> {
 fn load_content_by_name(app: AppHandle, file_name: String) -> Result<String, String> {
     use std::fs;
 
-    let app_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
-
-    let file_path = app_dir.join(file_name + ".md");
+    let notes = notes_dir(&app)?;
+    let file_path = notes.join(file_name + ".md");
 
     if file_path.exists() {
         let content = fs::read_to_string(&file_path)
             .map_err(|e| format!("Failed to read content file: {}", e))?;
         Ok(content)
     } else {
-        Ok(String::new()) // Return empty string if file doesn't exist
+        Ok(String::new())
     }
 }
 
@@ -77,16 +135,8 @@ fn load_content_by_name(app: AppHandle, file_name: String) -> Result<String, Str
 fn save_content_by_name(app: AppHandle, file_name: String, content: String) -> Result<(), String> {
     use std::fs;
 
-    let app_dir = app
-        .path()
-        .app_data_dir()
-        .expect("failed to retrieve app data dir");
-
-    // Ensure the directory exists
-    fs::create_dir_all(&app_dir)
-        .map_err(|e| format!("Failed to create app data dir: {}", e))?;
-
-    let file_path = app_dir.join(file_name + ".md");
+    let notes = notes_dir(&app)?;
+    let file_path = notes.join(file_name + ".md");
 
     fs::write(&file_path, content)
         .map_err(|e| format!("Failed to write content file: {}", e))?;
@@ -98,16 +148,8 @@ fn save_content_by_name(app: AppHandle, file_name: String, content: String) -> R
 fn add_file(app: AppHandle, file_name: String) -> Result<(), String> {
     use std::fs;
 
-    let app_dir = app
-        .path()
-        .app_data_dir()
-        .expect("failed to retrieve app data dir");
-
-    // Ensure the directory exists
-    fs::create_dir_all(&app_dir)
-        .map_err(|e| format!("Failed to create app data dir: {}", e))?;
-
-    let file_path = app_dir.join(file_name + ".md");
+    let notes = notes_dir(&app)?;
+    let file_path = notes.join(file_name + ".md");
 
     fs::write(&file_path, "")
         .map_err(|e| format!("Failed to create file: {}", e))?;
@@ -119,17 +161,10 @@ fn add_file(app: AppHandle, file_name: String) -> Result<(), String> {
 fn load_files(app: AppHandle) -> Result<Vec<FileInfo>, String> {
     use std::fs;
 
-    let app_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
-
-    if !app_dir.exists() {
-        return Ok(vec![]);
-    }
+    let notes = notes_dir(&app)?;
 
     let mut files = Vec::new();
-    for entry in fs::read_dir(app_dir).map_err(|e| format!("Failed to read app data dir: {}", e))? {
+    for entry in fs::read_dir(&notes).map_err(|e| format!("Failed to read notes dir: {}", e))? {
         let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
         let path = entry.path();
         if path.is_file() {
@@ -158,12 +193,8 @@ fn load_files(app: AppHandle) -> Result<Vec<FileInfo>, String> {
 fn delete_file_by_name(app: AppHandle, file_name: String) -> Result<(), String> {
     use std::fs;
 
-    let app_dir = app
-        .path()
-        .app_data_dir()
-        .expect("failed to retrieve app data dir");
-
-    let file_path = app_dir.join(file_name + ".md");
+    let notes = notes_dir(&app)?;
+    let file_path = notes.join(file_name + ".md");
 
     if file_path.exists() {
         fs::remove_file(&file_path)
@@ -178,6 +209,12 @@ fn delete_file_by_name(app: AppHandle, file_name: String) -> Result<(), String> 
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .setup(|app| {
+            if let Err(e) = migrate_notes_to_subdir(app.handle()) {
+                eprintln!("Notes migration skipped: {}", e);
+            }
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             greet,
             save_content,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,24 @@ fn notes_dir(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(notes)
 }
 
+// Resolve notes_dir/<file_name>.md, rejecting names that would let the path
+// escape notes/ (path separators, parent-dir refs, absolute paths, NUL).
+// All commands that accept a frontend-supplied file_name must go through this.
+fn notes_file_path(app: &AppHandle, file_name: &str) -> Result<PathBuf, String> {
+    if file_name.is_empty() {
+        return Err("File name cannot be empty".to_string());
+    }
+    if file_name.contains('/') || file_name.contains('\\') || file_name.contains('\0') {
+        return Err("File name contains invalid characters".to_string());
+    }
+    if file_name == "." || file_name == ".." {
+        return Err("Invalid file name".to_string());
+    }
+
+    let notes = notes_dir(app)?;
+    Ok(notes.join(format!("{}.md", file_name)))
+}
+
 // One-time migration: move every *.md file from the top of app_data_dir
 // into app_data_dir/notes/. Skips WebKit-managed files and skips any name
 // that would overwrite an existing file in notes/.
@@ -119,8 +137,7 @@ fn load_content(app: AppHandle) -> Result<String, String> {
 fn load_content_by_name(app: AppHandle, file_name: String) -> Result<String, String> {
     use std::fs;
 
-    let notes = notes_dir(&app)?;
-    let file_path = notes.join(file_name + ".md");
+    let file_path = notes_file_path(&app, &file_name)?;
 
     if file_path.exists() {
         let content = fs::read_to_string(&file_path)
@@ -135,8 +152,7 @@ fn load_content_by_name(app: AppHandle, file_name: String) -> Result<String, Str
 fn save_content_by_name(app: AppHandle, file_name: String, content: String) -> Result<(), String> {
     use std::fs;
 
-    let notes = notes_dir(&app)?;
-    let file_path = notes.join(file_name + ".md");
+    let file_path = notes_file_path(&app, &file_name)?;
 
     fs::write(&file_path, content)
         .map_err(|e| format!("Failed to write content file: {}", e))?;
@@ -148,8 +164,7 @@ fn save_content_by_name(app: AppHandle, file_name: String, content: String) -> R
 fn add_file(app: AppHandle, file_name: String) -> Result<(), String> {
     use std::fs;
 
-    let notes = notes_dir(&app)?;
-    let file_path = notes.join(file_name + ".md");
+    let file_path = notes_file_path(&app, &file_name)?;
 
     fs::write(&file_path, "")
         .map_err(|e| format!("Failed to create file: {}", e))?;
@@ -193,8 +208,7 @@ fn load_files(app: AppHandle) -> Result<Vec<FileInfo>, String> {
 fn delete_file_by_name(app: AppHandle, file_name: String) -> Result<(), String> {
     use std::fs;
 
-    let notes = notes_dir(&app)?;
-    let file_path = notes.join(file_name + ".md");
+    let file_path = notes_file_path(&app, &file_name)?;
 
     if file_path.exists() {
         fs::remove_file(&file_path)


### PR DESCRIPTION
closes #55

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store notes in `app_data_dir()/notes` and migrate existing files to stop WebKitGTK files appearing next to notes on Linux, and validate file names to prevent path traversal. Fixes #55.

- **Bug Fixes**
  - Notes are now read/written in `app_data_dir()/notes` via `notes_dir(&app)`, isolating them from `hsts-storage.*` and `cookies.*`.
  - Validates `file_name` in IPC commands via `notes_file_path` (rejects empty, `.`/`..`, path separators, NUL) to block path traversal.
  - All Rust file commands use the subdir; docs updated; `.gitignore` now ignores `claude-latest-session.txt`.

- **Migration**
  - On startup, `migrate_notes_to_subdir` moves top-level `*.md` files into `notes/`.
  - Skips `hsts-storage.md` and any file that would overwrite an existing note.

<sup>Written for commit 3cd83720b54fa938453f90207c01f4e51a142445. Summary will update on new commits. <a href="https://cubic.dev/pr/AlbertArakelyan/Lumark/pull/57?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

