### PR TITLE
fix: set app window width to 1280

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,7 +13,7 @@
     "windows": [
       {
         "title": "Lumark",
-        "width": 1200,
+        "width": 1280,
         "height": 744
       }
     ],


### PR DESCRIPTION
Closes #62

Changes window width from 1200 to 1280 in src-tauri/tauri.conf.json.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the app’s default window width to 1280 (from 1200) in `src-tauri/tauri.conf.json` to match the 1280px layout baseline and prevent cramped UI on first launch.

<sup>Written for commit 10ecd7740878aa6f09cb994e72349d475995e87d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AlbertArakelyan/Lumark/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

