### PR TITLE
Improve editor mode button hover feedback

### DIFF
--- a/src/components/Editor/EditorMode.tsx
+++ b/src/components/Editor/EditorMode.tsx
@@ -20,7 +20,7 @@ const EditorMode = () => {
     <button
       key={button.value}
       onClick={() => handleEditorModeChange(button.value)}
-      className={`${button.value === editorMode ? 'bg-gray-300' : ''} inline-flex items-center p-1 border border-gray-300 text-sm font-medium rounded-md focus:outline-none hover:cursor-pointer hover:bg-gray-200 transition-colors`}
+      className={`${button.value === editorMode ? 'bg-gray-300' : 'hover:bg-gray-200'} inline-flex items-center p-1 border border-gray-300 text-sm font-medium rounded-md focus:outline-none hover:cursor-pointer transition-colors`}
     >
       {button.icon}
     </button>

--- a/src/components/Editor/EditorMode.tsx
+++ b/src/components/Editor/EditorMode.tsx
@@ -20,7 +20,7 @@ const EditorMode = () => {
     <button
       key={button.value}
       onClick={() => handleEditorModeChange(button.value)}
-      className={`${button.value === editorMode ? 'bg-gray-300' : ''} inline-flex items-center p-1 border border-gray-300 text-sm font-medium rounded-md focus:outline-none hover:cursor-pointer`}
+      className={`${button.value === editorMode ? 'bg-gray-300' : ''} inline-flex items-center p-1 border border-gray-300 text-sm font-medium rounded-md focus:outline-none hover:cursor-pointer hover:bg-gray-200 transition-colors`}
     >
       {button.icon}
     </button>

--- a/test/EditorMode.test.mjs
+++ b/test/EditorMode.test.mjs
@@ -8,12 +8,16 @@ const editorModeSource = await readFile(
   'utf8',
 );
 
-test('mode selection buttons transition to a hover background', () => {
-  const buttonsContent = editorModeSource.slice(
-    editorModeSource.indexOf('const buttonsContent'),
-    editorModeSource.indexOf('\n\n  return'),
+test('mode selection buttons preserve the active background on hover', () => {
+  const modeButton = editorModeSource.match(
+    /<button\s+key=\{button\.value\}[\s\S]*?className=\{`([^`]*)`\}[\s\S]*?>/,
   );
 
-  assert.match(buttonsContent, /hover:bg-gray-200/);
-  assert.match(buttonsContent, /transition-colors/);
+  assert.ok(modeButton, 'mode button className should be present');
+  assert.match(
+    modeButton[1],
+    /\$\{button\.value === editorMode \? 'bg-gray-300' : 'hover:bg-gray-200'\}/,
+    'active and inactive mode colors must be mutually exclusive',
+  );
+  assert.match(modeButton[1], /\btransition-colors\b/);
 });

--- a/test/EditorMode.test.mjs
+++ b/test/EditorMode.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import { URL } from 'node:url';
+
+const editorModeSource = await readFile(
+  new URL('../src/components/Editor/EditorMode.tsx', import.meta.url),
+  'utf8',
+);
+
+test('mode selection buttons transition to a hover background', () => {
+  const buttonsContent = editorModeSource.slice(
+    editorModeSource.indexOf('const buttonsContent'),
+    editorModeSource.indexOf('\n\n  return'),
+  );
+
+  assert.match(buttonsContent, /hover:bg-gray-200/);
+  assert.match(buttonsContent, /transition-colors/);
+});


### PR DESCRIPTION
## Summary
- add a gray hover background and transition to inactive editor mode buttons
- keep the active gray background unchanged while its button is hovered
- strengthen the focused test so it targets the mapped mode button class directly

## Checks
- `OPENSSL_CONF=/dev/null node --test test/EditorMode.test.mjs` (base failed, corrected head passed in the clean network-off verifier)
- `corepack yarn@1.22.22 eslint src/components/Editor/EditorMode.tsx test/EditorMode.test.mjs` (passed)
- `corepack yarn@1.22.22 build` (passed)
- full `yarn lint` still reports existing findings in unrelated files

## Limitations
- No manual browser visual verification was performed.

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1020:start -->
### Verification

[Northset proof-of-pass receipt M-1020](https://northset-oss.github.io/verification-pilot/receipts/M-1020/)  
This record covers Northset’s own contribution; it is not maintainer verification.
Maintainers can request a separate, private run for a PR already in their queue at oss@northset.ai.
For repositories already onboarded with Northset, adding `northset-verify` to a PR requests a run on that PR.
<!-- northset-receipt:M-1020:end -->
