### PR TITLE
fix: Create a header style top bar, and put `View Selection` inside of it at the right edge

### DIFF
--- a/src/components/Layouts/MainLayout/MainLayout.tsx
+++ b/src/components/Layouts/MainLayout/MainLayout.tsx
@@ -2,11 +2,15 @@ import { FC, PropsWithChildren } from 'react';
 import FilesPanel from './FilesPanel/FilesPanel';
 
 const MainLayout: FC<PropsWithChildren> = ({ children }) => (
-  <div className="flex items-start">
-    <aside className="max-w-64 w-full p-2 border-r border-border-color min-h-screen sticky top-0">
-      <FilesPanel />
-    </aside>
-    <main className="flex-1">
+  <div className="flex flex-col h-screen">
+    <header className="h-12 border-b border-border-color flex items-center justify-end px-4">
+      <span>View Selection</span>
+    </header>
+    <div className="flex flex-1 overflow-hidden">
+      <aside className="max-w-64 w-full p-2 border-r border-border-color overflow-y-auto">
+        <FilesPanel />
+      </aside>
+      <main className="flex-1 overflow-auto">
       {children}
     </main>
   </div>


### PR DESCRIPTION
Closes #59

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a header-style top bar in `MainLayout` and moves "View Selection" into it, right-aligned. Updates the layout to a column flex with scrollable sidebar and main area to meet #59.

<sup>Written for commit 92c706c7da077d48d071067b7eaa09286b06a302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AlbertArakelyan/Lumark/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

