### PR TITLE
Header corrections

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -13,7 +13,6 @@ import 'github-markdown-css/github-markdown-light.css'; // TODO: remove light th
 // Reference: https://github.com/sindresorhus/github-markdown-css
 
 import { useAppContext } from '../../contexts/AppProvider.tsx';
-import EditorMode from './EditorMode.tsx';
 import { EditorModeEnum } from '../../types/editor/editorEnums.ts';
 
 // Try also react-simple-code-editor [https://www.npmjs.com/package/react-simple-code-editor]
@@ -82,7 +81,6 @@ const Editor = () => {
 
   return (
     <>
-      <EditorMode />
       <div className="flex items-start justify-between gap-2 p-2">
         <div className={`w-1/2 ${editorMode === EditorModeEnum.PREVIEW ? 'hidden' : ''} ${editorMode === EditorModeEnum.EDIT ? '!w-full' : ''}`}>
           <div id="editor-container"></div>

--- a/src/components/Editor/EditorMode.tsx
+++ b/src/components/Editor/EditorMode.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useAppContext } from '../../contexts/AppProvider.tsx';
 import { EditorModeEnum } from '../../types/editor/editorEnums.ts';
-import { EyeIcon, PencilIcon, SplitSquareHorizontal, ChevronDown } from 'lucide-react';
+import { EyeIcon, PencilIcon, SplitSquareHorizontal } from 'lucide-react';
 
 const editorModeButtons: {
   label: string;
@@ -27,15 +27,8 @@ const EditorMode = () => {
   ));
 
   return (
-    <div className="flex items-center justify-start flex-col fixed top-0 left-1/2 -translate-x-1/2 z-10 group">
-      <div className="w-max items-center gap-1 bg-white py-1 group-hover:flex hidden">
-        {buttonsContent}
-      </div>
-      <button
-        className="py-1 px-2 hover:bg-gray-100 hover:text-gray-900 focus:outline-none hover:cursor-pointer rounded-b-lg group-hover:bg-gray-100"
-      >
-        <ChevronDown className="w-4 h-4 group-hover:rotate-180 transition-transform" />
-      </button>
+    <div className="flex w-max items-center gap-1">
+      {buttonsContent}
     </div>
   );
 };

--- a/src/components/Layouts/MainLayout/MainLayout.tsx
+++ b/src/components/Layouts/MainLayout/MainLayout.tsx
@@ -11,8 +11,9 @@ const MainLayout: FC<PropsWithChildren> = ({ children }) => (
         <FilesPanel />
       </aside>
       <main className="flex-1 overflow-auto">
-      {children}
-    </main>
+        {children}
+      </main>
+    </div>
   </div>
 );
 

--- a/src/components/Layouts/MainLayout/MainLayout.tsx
+++ b/src/components/Layouts/MainLayout/MainLayout.tsx
@@ -1,10 +1,11 @@
 import { FC, PropsWithChildren } from 'react';
 import FilesPanel from './FilesPanel/FilesPanel';
+import EditorMode from '../../Editor/EditorMode';
 
 const MainLayout: FC<PropsWithChildren> = ({ children }) => (
   <div className="flex flex-col h-screen">
-    <header className="h-12 border-b border-border-color flex items-center justify-end px-4">
-      <span>View Selection</span>
+    <header className="h-9 border-b border-border-color flex items-center justify-end px-4">
+      <EditorMode />
     </header>
     <div className="flex flex-1 overflow-hidden">
       <aside className="max-w-64 w-full p-2 border-r border-border-color overflow-y-auto">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved the editor mode buttons into the main header and made them always visible, replacing the hover dropdown. This cleans up the Editor and standardizes the header.

- **Refactors**
  - Moved `EditorMode` from the editor canvas to the `MainLayout` header.
  - Simplified `EditorMode` UI to inline buttons; removed the hover menu and `ChevronDown`.
  - Set header height to `h-9` and removed the "View Selection" label.
  - Removed `EditorMode` import and render from `Editor.tsx`.

<sup>Written for commit 949cf7d2703aed07b0a4973a228213ea926ecfdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AlbertArakelyan/Lumark/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

