### PR TITLE
fix(58): scroll the files list independently of the editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import Editor from './components/Editor/Editor.tsx';
 import MainLayout from './components/Layouts/MainLayout/MainLayout.tsx';
 
 const App = () => (
-  <div className="bg-surface text-text-color">
+  <div className="h-full bg-surface text-text-color">
     <MainLayout>
       <Editor />
     </MainLayout>

--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -8,3 +8,9 @@
 html, body {
   font-size: 16px;
 }
+
+/* The app shell owns every scroll container — the window itself must never scroll. */
+html, body, #root {
+  height: 100%;
+  overflow: hidden;
+}

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -82,10 +82,10 @@ const Editor = () => {
   return (
     <>
       <div className="flex items-start justify-between gap-2 p-2">
-        <div className={`w-1/2 ${editorMode === EditorModeEnum.PREVIEW ? 'hidden' : ''} ${editorMode === EditorModeEnum.EDIT ? '!w-full' : ''}`}>
+        <div className={`w-1/2 min-w-0 ${editorMode === EditorModeEnum.PREVIEW ? 'hidden' : ''} ${editorMode === EditorModeEnum.EDIT ? '!w-full' : ''}`}>
           <div id="editor-container"></div>
         </div>
-        <div className={`w-1/2 ${editorMode === EditorModeEnum.EDIT ? 'hidden' : ''} ${editorMode === EditorModeEnum.PREVIEW ? '!w-full' : ''}`}>
+        <div className={`w-1/2 min-w-0 ${editorMode === EditorModeEnum.EDIT ? 'hidden' : ''} ${editorMode === EditorModeEnum.PREVIEW ? '!w-full' : ''}`}>
           <article className="markdown-body">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}

--- a/src/components/Layouts/MainLayout/FilesPanel/FilesPanel.tsx
+++ b/src/components/Layouts/MainLayout/FilesPanel/FilesPanel.tsx
@@ -2,9 +2,13 @@ import FilesSearch from './FilesSearch';
 import FilesList from './FilesList';
 
 const FilesPanel = () => (
-  <div>
-    <FilesSearch />
-    <FilesList />
+  <div className="flex flex-col h-full min-h-0">
+    <div className="shrink-0 p-2">
+      <FilesSearch />
+    </div>
+    <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-2">
+      <FilesList />
+    </div>
   </div>
 );
 

--- a/src/components/Layouts/MainLayout/MainLayout.tsx
+++ b/src/components/Layouts/MainLayout/MainLayout.tsx
@@ -3,15 +3,15 @@ import FilesPanel from './FilesPanel/FilesPanel';
 import EditorMode from '../../Editor/EditorMode';
 
 const MainLayout: FC<PropsWithChildren> = ({ children }) => (
-  <div className="flex flex-col h-screen">
-    <header className="h-9 border-b border-border-color flex items-center justify-end px-4">
+  <div className="flex flex-col h-dvh overflow-hidden">
+    <header className="h-9 shrink-0 border-b border-border-color flex items-center justify-end px-4">
       <EditorMode />
     </header>
-    <div className="flex flex-1 overflow-hidden">
-      <aside className="max-w-64 w-full p-2 border-r border-border-color overflow-y-auto">
+    <div className="flex flex-1 min-h-0 overflow-hidden">
+      <aside className="w-64 shrink-0 min-h-0 border-r border-border-color">
         <FilesPanel />
       </aside>
-      <main className="flex-1 overflow-auto">
+      <main className="flex-1 min-w-0 min-h-0 overflow-auto">
         {children}
       </main>
     </div>


### PR DESCRIPTION
closes #58 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the files sidebar scroll independently from the editor, with the header fixed. Fixes #58 by switching to a full-height app shell with separate scroll areas.

- **Bug Fixes**
  - Set `html, body, #root` to `height: 100%` and `overflow: hidden` to prevent window scrolling.
  - Updated layout to use `h-dvh` and `min-h-0/min-w-0`, creating independent scroll for sidebar and editor while keeping the header fixed.
  - Refined FilesPanel: search stays pinned; files list scrolls. Added `min-w-0` to editor/preview panes to avoid flex overflow.

<sup>Written for commit 701ed49824bb60aa7f093b47e5b56650fe821c16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AlbertArakelyan/Lumark/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

