### PR TITLE
70 implement search

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lumark",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "identifier": "com.albertarakelyan.lumark",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/src/components/Layouts/MainLayout/FilesPanel/FilesList.tsx
+++ b/src/components/Layouts/MainLayout/FilesPanel/FilesList.tsx
@@ -2,17 +2,19 @@ import { useAppContext } from '../../../../contexts/AppProvider';
 import FileItem from './FileItem';
 
 const FilesList = () => {
-  const { files } = useAppContext();
+  const { filteredFiles, isSearching } = useAppContext();
 
   const filesContent = (
-    files.map((file) => (
+    filteredFiles.map((file) => (
       <FileItem key={file.file_name} file={file} />
     ))
   );
 
+  const emptyMessage = isSearching ? 'No files match your search.' : 'No files found.';
+
   return (
     <div className="mt-1">
-      {filesContent.length > 0 ? filesContent : <div>No files found.</div>}
+      {filesContent.length > 0 ? filesContent : <div>{emptyMessage}</div>}
     </div>
   );
 };

--- a/src/components/Layouts/MainLayout/FilesPanel/FilesSearch.tsx
+++ b/src/components/Layouts/MainLayout/FilesPanel/FilesSearch.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { SquarePenIcon } from 'lucide-react';
+import { SearchIcon, SquarePenIcon, XIcon } from 'lucide-react';
 import Button from '../../../UI/Button/Button';
 import Input from '../../../UI/Input/Input';
 import { useAppContext } from '../../../../contexts/AppProvider';
 
 const FilesSearch = () => {
-  const { fetchFiles } = useAppContext();
+  const { fetchFiles, searchQuery, setSearchQuery } = useAppContext();
 
   const [isAddingFile, setIsAddingFile] = useState(false);
   const [fileName, setFileName] = useState('');
@@ -31,6 +31,8 @@ const FilesSearch = () => {
 
       setIsAddingFile(false);
       setFileName('');
+      // Clear the search so the freshly added file is visible in the list
+      setSearchQuery('');
     } catch (error) {
       console.error('Error adding file:', error);
     }
@@ -38,6 +40,20 @@ const FilesSearch = () => {
 
   const handleFileNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFileName(e.target.value);
+  };
+
+  const handleSearchQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+
+  const handleClearSearch = () => {
+    setSearchQuery('');
+  };
+
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      handleClearSearch();
+    }
   };
 
   return (
@@ -75,6 +91,22 @@ const FilesSearch = () => {
             key="file-search-input"
             placeholder="Search"
             rounded="rounded"
+            icon={searchQuery ? (
+              <Button
+                variant="ghost"
+                size="square-icon"
+                rounded="circle"
+                className="!p-0.5"
+                icon={<XIcon size={16} />}
+                aria-label="Clear search"
+                onClick={handleClearSearch}
+              />
+            ) : (
+              <SearchIcon size={16} className="text-muted-text" />
+            )}
+            value={searchQuery}
+            onChange={handleSearchQueryChange}
+            onKeyDown={handleSearchKeyDown}
           />
           <Button
             variant="ghost"

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -1,7 +1,10 @@
-import { createContext, Dispatch, ReactNode, SetStateAction, useContext, useEffect, useState } from 'react';
+import { createContext, Dispatch, ReactNode, SetStateAction, useContext, useEffect, useMemo, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { EditorModeEnum } from '../types/editor/editorEnums.ts';
 import { IFileInfo } from '../types/file/fileTypes.ts';
+import useDebounce from '../hooks/useDebounce.ts';
+
+const SEARCH_DEBOUNCE_DELAY = 300;
 
 interface IAppContext {
   content: string;
@@ -9,6 +12,10 @@ interface IAppContext {
   editorMode: EditorModeEnum;
   handleEditorModeChange: (mode: EditorModeEnum) => void;
   files: IFileInfo[];
+  filteredFiles: IFileInfo[];
+  searchQuery: string;
+  setSearchQuery: Dispatch<SetStateAction<string>>;
+  isSearching: boolean;
   selectFile: (fileName: string) => void;
   deleteFile: (fileName: string) => Promise<void>;
   selectedFile: string | null;
@@ -22,6 +29,18 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   const [editorMode, setEditorMode] = useState<EditorModeEnum>(EditorModeEnum.SPLIT);
   const [files, setFiles] = useState<IFileInfo[]>([]);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const debouncedSearchQuery = useDebounce(searchQuery, SEARCH_DEBOUNCE_DELAY);
+  const normalizedSearchQuery = debouncedSearchQuery.trim().toLowerCase();
+
+  const filteredFiles = useMemo(() => {
+    if (!normalizedSearchQuery) {
+      return files;
+    }
+
+    return files.filter((file) => file.file_name.toLowerCase().includes(normalizedSearchQuery));
+  }, [files, normalizedSearchQuery]);
 
   const handleEditorModeChange = (mode: EditorModeEnum) => {
     setEditorMode(mode);
@@ -132,6 +151,10 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     editorMode,
     handleEditorModeChange,
     files,
+    filteredFiles,
+    searchQuery,
+    setSearchQuery,
+    isSearching: Boolean(normalizedSearchQuery),
     selectFile,
     deleteFile,
     selectedFile,

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+const useDebounce = <T>(value: T, delay = 300): T => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => setDebouncedValue(value), delay);
+
+    return () => clearTimeout(timeoutId);
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;


### PR DESCRIPTION
closes #70 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements debounced, case-insensitive file search in the Files panel. Previously all files were shown; now the list filters by name after 300 ms and shows a search-aware empty state.

- Adds `searchQuery`, `setSearchQuery`, `filteredFiles`, and `isSearching` to context; `FilesList` renders `filteredFiles` and updates the empty-list message.
- Search input shows a clear button, supports Escape to clear, and clears the query after creating a file so the new file is visible.
- Introduces a reusable `useDebounce` hook (300 ms) for client-side filtering.
- Bumps app version to 0.7.0.

<sup>Written for commit 1b6059da4ac35e887f4cbdcb159a64fc3cbb8676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AlbertArakelyan/Lumark/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

