### PR TITLE
72 implement file name edit

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -219,6 +219,31 @@ fn delete_file_by_name(app: AppHandle, file_name: String) -> Result<(), String> 
     }
 }
 
+#[tauri::command]
+fn rename_file_by_name(app: AppHandle, old_file_name: String, new_file_name: String) -> Result<(), String> {
+    use std::fs;
+
+    let old_path = notes_file_path(&app, &old_file_name)?;
+    let new_path = notes_file_path(&app, &new_file_name)?;
+
+    if !old_path.exists() {
+        return Err("File not found".to_string());
+    }
+
+    if old_path == new_path {
+        return Ok(());
+    }
+
+    if new_path.exists() {
+        return Err(format!("A file named \"{}\" already exists", new_file_name));
+    }
+
+    fs::rename(&old_path, &new_path)
+        .map_err(|e| format!("Failed to rename file: {}", e))?;
+
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -237,7 +262,8 @@ pub fn run() {
             load_files,
             load_content_by_name,
             save_content_by_name,
-            delete_file_by_name
+            delete_file_by_name,
+            rename_file_by_name
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lumark",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "identifier": "com.albertarakelyan.lumark",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/src/components/Layouts/MainLayout/FilesPanel/FileItem.tsx
+++ b/src/components/Layouts/MainLayout/FilesPanel/FileItem.tsx
@@ -1,20 +1,30 @@
-import { FC } from 'react';
-import { Trash2Icon } from 'lucide-react';
+import { ChangeEvent, FC, KeyboardEvent, MouseEvent, useState } from 'react';
+import { BanIcon, CheckIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import { IFileItemProps } from './types';
 import { useAppContext } from '../../../../contexts/AppProvider';
 import Button from '../../../UI/Button/Button';
+import Input from '../../../UI/Input/Input';
 
 const FileItem: FC<IFileItemProps> = ({ file }) => {
-  const { selectFile, selectedFile, deleteFile } = useAppContext();
+  const { selectFile, selectedFile, deleteFile, renameFile } = useAppContext();
+
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [fileName, setFileName] = useState(file.file_name);
+  const [renameError, setRenameError] = useState('');
 
   const epoch = Number(file.date_created);
+  const trimmedFileName = fileName.trim();
+  const isSaveDisabled = !trimmedFileName || trimmedFileName === file.file_name;
 
-  const handleFileClick = (fileName: string) => {
-    console.log(`File clicked: ${fileName}`);
-    selectFile(fileName);
+  const handleFileClick = () => {
+    if (isEditingName) {
+      return;
+    }
+
+    selectFile(file.file_name);
   };
 
-  const handleDeleteClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleDeleteClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation(); // Prevent the click event from bubbling up to the file item
 
     // TODO: Replace the window.confirm with a custom modal for better UX
@@ -24,28 +34,115 @@ const FileItem: FC<IFileItemProps> = ({ file }) => {
       return;
     }
 
-    console.log(`Delete clicked for file: ${file.file_name}`);
-    // Call the delete function from context here, e.g., deleteFile(file.file_name);
     deleteFile(file.file_name);
+  };
+
+  const handleEditClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation(); // Prevent the click event from bubbling up to the file item
+
+    setFileName(file.file_name);
+    setRenameError('');
+    setIsEditingName(true);
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditingName(false);
+    setFileName(file.file_name);
+    setRenameError('');
+  };
+
+  const handleSaveEdit = async () => {
+    if (isSaveDisabled) {
+      return;
+    }
+
+    try {
+      await renameFile(file.file_name, trimmedFileName);
+      setIsEditingName(false);
+      setRenameError('');
+    } catch (error) {
+      setRenameError(typeof error === 'string' ? error : 'Failed to rename file');
+    }
+  };
+
+  const handleFileNameChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setFileName(e.target.value);
+    setRenameError('');
+  };
+
+  const handleFileNameKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSaveEdit();
+    }
+
+    if (e.key === 'Escape') {
+      handleCancelEdit();
+    }
   };
 
   return (
     <div
       key={file.file_name}
       className={`group flex flex-col gap-y-0.5 p-2 hover:bg-gray-bg-hover cursor-pointer rounded-xl relative after:absolute after:bottom-0 after:left-0 after:w-full after:h-px after:bg-border-color/50 after:content-[''] ${file.file_name === selectedFile ? 'bg-gray-bg-active' : ''}`}
-      onClick={() => handleFileClick(file.file_name)}
+      onClick={handleFileClick}
     >
-      <h3 className="font-medium">{file.file_name}</h3>
-      <p className="text-sm text-muted-text">
+      {isEditingName ? (
+        <div
+          className="flex items-center gap-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Input
+            autoFocus
+            rounded="rounded"
+            value={fileName}
+            error={renameError}
+            onChange={handleFileNameChange}
+            onKeyDown={handleFileNameKeyDown}
+          />
+          <Button
+            variant="ghost"
+            size="square-icon"
+            className="text-success"
+            icon={<CheckIcon size={20} />}
+            aria-label="Save file name"
+            disabled={isSaveDisabled}
+            onClick={handleSaveEdit}
+          />
+          <Button
+            variant="ghost"
+            size="square-icon"
+            className="text-danger"
+            icon={<BanIcon size={20} />}
+            aria-label="Cancel renaming"
+            onClick={handleCancelEdit}
+          />
+        </div>
+      ) : (
+        <h3 className="font-medium truncate pr-7">{file.file_name}</h3>
+      )}
+      <p className={`text-sm text-muted-text pr-7 ${renameError ? 'mt-4' : ''}`}>
         Created: <span>{new Date(epoch * 1000).toLocaleDateString()}</span>
       </p>
-      <Button
-        className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
-        variant="ghost"
-        size="square-icon"
-        icon={<Trash2Icon size={20} />}
-        onClick={handleDeleteClick}
-      />
+      {!isEditingName && (
+        <div className="absolute top-1/2 -translate-y-1/2 right-2 flex flex-col gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+          <Button
+            className="!p-0.5"
+            variant="ghost"
+            size="square-icon"
+            icon={<PencilIcon size={14} />}
+            aria-label="Rename file"
+            onClick={handleEditClick}
+          />
+          <Button
+            className="!p-0.5"
+            variant="ghost"
+            size="square-icon"
+            icon={<Trash2Icon size={14} />}
+            aria-label="Delete file"
+            onClick={handleDeleteClick}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -18,6 +18,7 @@ interface IAppContext {
   isSearching: boolean;
   selectFile: (fileName: string) => void;
   deleteFile: (fileName: string) => Promise<void>;
+  renameFile: (oldFileName: string, newFileName: string) => Promise<void>;
   selectedFile: string | null;
   fetchFiles: () => Promise<void>;
 }
@@ -65,6 +66,20 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       });
     } catch (error) {
       console.error('Failed to delete file:', error);
+    }
+  };
+
+  const renameFile = async (oldFileName: string, newFileName: string) => {
+    try {
+      await invoke('rename_file_by_name', { oldFileName, newFileName });
+      await fetchFiles();
+      // Keep the open file selected under its new name
+      setSelectedFile((currentSelectedFile) => (
+        currentSelectedFile === oldFileName ? newFileName : currentSelectedFile
+      ));
+    } catch (error) {
+      console.error('Failed to rename file:', error);
+      throw error;
     }
   };
 
@@ -157,6 +172,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     isSearching: Boolean(normalizedSearchQuery),
     selectFile,
     deleteFile,
+    renameFile,
     selectedFile,
     fetchFiles,
   };


### PR DESCRIPTION
closes #72 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable inline file renaming in the Files panel (Linear #72). Previously filenames were fixed; now users can rename in place with validation, and the selection remains on the renamed file.

- Adds Tauri command `rename_file_by_name` that validates source existence, prevents collisions, and no-ops if unchanged; errors surface to the UI.
- Adds `renameFile` in app context to invoke the command, refresh the file list, and preserve selection when the open file is renamed.
- Updates `FileItem` to support inline edit: hover pencil to rename, Enter to save, Esc to cancel; save is disabled for empty/unchanged names; shows backend errors; hover actions now show rename and delete.
- Bumps app version to 0.7.1.

<sup>Written for commit 8da99c44d67a8b902933c294f3bcddc7730e4f66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AlbertArakelyan/Lumark/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

