### PR TITLE
74 fix editing while there is no selected file

### DIFF
--- a/.claude/rules/editor.md
+++ b/.claude/rules/editor.md
@@ -13,6 +13,7 @@ The editor mounts **CodeMirror 6 imperatively** alongside a **react-markdown** p
 3. **`isEditorContentSetInitially` gates the initial doc push** from React `content` → CodeMirror. It's reset to `false` when `selectedFile` changes so the new file's content is pushed once, then edits flow back through the `updateListener` without ping-ponging.
 4. **Updates back into React happen via `updateListener.of(...)`** calling `setContent(update.state.doc.toString())`. Don't introduce a parallel React-side sync.
 5. **Both panes stay mounted in SPLIT mode**; `EDIT` and `PREVIEW` hide the other half via `hidden` + `!w-full`. Don't replace this with conditional rendering — see invariant 2.
+6. **The whole `Editor` is only mounted when a file is selected.** `App.tsx` renders `<NoFileSelected />` in its place when `selectedFile` is `null` — otherwise users can type into a buffer with nowhere to save, which silently loses notes. The construction effect therefore runs when the first file is selected rather than at app start; its cleanup destroys the `EditorView`, so this unmount/remount is safe. Gate this on `selectedFile` only — never on `editorMode` (see invariant 2).
 
 ## Adding CodeMirror extensions
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lumark",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "identifier": "com.albertarakelyan.lumark",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,18 @@
 import Editor from './components/Editor/Editor.tsx';
+import NoFileSelected from './components/Editor/NoFileSelected.tsx';
 import MainLayout from './components/Layouts/MainLayout/MainLayout.tsx';
+import { useAppContext } from './contexts/AppProvider.tsx';
 
-const App = () => (
-  <div className="h-full bg-surface text-text-color">
-    <MainLayout>
-      <Editor />
-    </MainLayout>
-  </div>
-);
+const App = () => {
+  const { selectedFile } = useAppContext();
+
+  return (
+    <div className="h-full bg-surface text-text-color">
+      <MainLayout>
+        {selectedFile ? <Editor /> : <NoFileSelected />}
+      </MainLayout>
+    </div>
+  );
+};
 
 export default App;

--- a/src/components/Editor/CLAUDE.md
+++ b/src/components/Editor/CLAUDE.md
@@ -9,6 +9,7 @@ The editor mounts **CodeMirror 6 imperatively** alongside a **react-markdown** p
 3. **`isEditorContentSetInitially` gates the initial doc push** from React `content` → CodeMirror. It's reset to `false` whenever `selectedFile` changes so the new file's content is pushed once, then ongoing edits flow back through the `updateListener` without ping-ponging.
 4. **Updates back into React happen via the `updateListener.of(...)` extension**, calling `setContent(update.state.doc.toString())`. Don't introduce a parallel React-side sync — you'll get an autosave/reload loop.
 5. **Both panes stay mounted in `SPLIT` mode**; `EDIT` and `PREVIEW` modes hide the other half via Tailwind `hidden` + `!w-full`. Don't replace this with conditional rendering — see invariant 2.
+6. **The whole `Editor` is only mounted when a file is selected.** `App.tsx` renders `<NoFileSelected />` in its place when `selectedFile` is `null` — otherwise users can type into a buffer with nowhere to save, which silently loses notes. The construction effect therefore runs when the first file is selected rather than at app start; its cleanup destroys the `EditorView`, so this unmount/remount is safe. Gate this on `selectedFile` only — never on `editorMode` (see invariant 2).
 
 ## Adding CodeMirror extensions
 

--- a/src/components/Editor/EditorMode.tsx
+++ b/src/components/Editor/EditorMode.tsx
@@ -14,17 +14,26 @@ const editorModeButtons: {
 ];
 
 const EditorMode = () => {
-  const { editorMode, handleEditorModeChange } = useAppContext();
+  const { editorMode, handleEditorModeChange, selectedFile } = useAppContext();
 
-  const buttonsContent = editorModeButtons.map((button) => (
-    <button
-      key={button.value}
-      onClick={() => handleEditorModeChange(button.value)}
-      className={`${button.value === editorMode ? 'bg-gray-300' : 'hover:bg-gray-200'} inline-flex items-center p-1 border border-gray-300 text-sm font-medium rounded-md focus:outline-none hover:cursor-pointer transition-colors`}
-    >
-      {button.icon}
-    </button>
-  ));
+  // Without a selected file there is no editor to switch modes on
+  const isDisabled = !selectedFile;
+
+  const buttonsContent = editorModeButtons.map((button) => {
+    const stateClassName = button.value === editorMode ? 'bg-gray-300' : (isDisabled ? '' : 'hover:bg-gray-200');
+    const interactionClassName = isDisabled ? 'cursor-not-allowed opacity-50' : 'hover:cursor-pointer';
+
+    return (
+      <button
+        key={button.value}
+        disabled={isDisabled}
+        onClick={() => handleEditorModeChange(button.value)}
+        className={`${stateClassName} ${interactionClassName} inline-flex items-center p-1 border border-gray-300 text-sm font-medium rounded-md focus:outline-none transition-colors`}
+      >
+        {button.icon}
+      </button>
+    );
+  });
 
   return (
     <div className="flex w-max items-center gap-1">

--- a/src/components/Editor/NoFileSelected.tsx
+++ b/src/components/Editor/NoFileSelected.tsx
@@ -1,0 +1,8 @@
+const NoFileSelected = () => (
+  <div className="h-full flex flex-col items-center justify-center gap-y-1 p-4 text-center">
+    <h2 className="text-2xl font-medium">No file is selected</h2>
+    <p className="text-sm text-muted-text">Please select a file and start editing</p>
+  </div>
+);
+
+export default NoFileSelected;


### PR DESCRIPTION
closes #74 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents editing when no file is selected to avoid losing unsaved notes. Previously the editor mounted at app start and accepted input without a selected file; now the app shows a placeholder and disables editor mode buttons until a file is chosen.

- Gates the editor in `App.tsx` on `selectedFile`; renders a `NoFileSelected` placeholder otherwise.
- Disables editor mode buttons when no `selectedFile`; adds non-interactive styles.
- Documents the invariant that the editor only mounts when a file is selected; unmount cleanup destroys the `EditorView`.
- Bumps app version to 0.7.2.
- No changes once a file is selected; no migrations required.

<sup>Written for commit f0694d3617a405f54d67359d3063b9941686d339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AlbertArakelyan/Lumark/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

