### PR TITLE
doc(81): marked folders/workspaces milestone as done in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,10 @@
 - [ ] Support Tab and Shift+Tab (for tabbing and back-tabbing)
 - [ ] Support Key Shortcuts (Ctrl+B, Ctrl+I, Ctrl+U, etc.)
 - [x] Multiple files selection
-- [ ] Support folders/workspaces
+- [x] Support folders/workspaces
 - [ ] Dark mode
 - [ ] Export to PDF
 - [ ] Support `mermaid` diagrams
-
-
 
 ## <img height="18" src="https://octicons-col.vercel.app/law/2f5bff"> License
 


### PR DESCRIPTION
closes #81

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the README to mark folders/workspaces support as complete, reflecting the finished milestone. This closes issue #81.

<sup>Written for commit 2b48009d0aed02540f34d10117c0e45818dc03c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AlbertArakelyan/Lumark/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

