### PR TITLE
78 make side panel togglabel

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lumark",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "com.albertarakelyan.lumark",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/src/components/Editor/EditorMode.tsx
+++ b/src/components/Editor/EditorMode.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import { useAppContext } from '../../contexts/AppProvider.tsx';
 import { EditorModeEnum } from '../../types/editor/editorEnums.ts';
 import { EyeIcon, PencilIcon, SplitSquareHorizontal } from 'lucide-react';
+import ToolbarButton from '../UI/ToolbarButton/ToolbarButton.tsx';
 
 const editorModeButtons: {
   label: string;
   value: EditorModeEnum;
-  icon: React.ReactNode;
+  icon: ReactNode;
 }[] = [
   { label: 'Split', value: EditorModeEnum.SPLIT, icon: <SplitSquareHorizontal className="w-4 h-4" /> },
   { label: 'Edit', value: EditorModeEnum.EDIT, icon: <PencilIcon className="w-4 h-4" /> },
@@ -19,21 +20,18 @@ const EditorMode = () => {
   // Without a selected file there is no editor to switch modes on
   const isDisabled = !selectedFile;
 
-  const buttonsContent = editorModeButtons.map((button) => {
-    const stateClassName = button.value === editorMode ? 'bg-gray-300' : (isDisabled ? '' : 'hover:bg-gray-200');
-    const interactionClassName = isDisabled ? 'cursor-not-allowed opacity-50' : 'hover:cursor-pointer';
-
-    return (
-      <button
-        key={button.value}
-        disabled={isDisabled}
-        onClick={() => handleEditorModeChange(button.value)}
-        className={`${stateClassName} ${interactionClassName} inline-flex items-center p-1 border border-gray-300 text-sm font-medium rounded-md focus:outline-none transition-colors`}
-      >
-        {button.icon}
-      </button>
-    );
-  });
+  const buttonsContent = editorModeButtons.map((button) => (
+    <ToolbarButton
+      key={button.value}
+      isActive={button.value === editorMode}
+      disabled={isDisabled}
+      onClick={() => handleEditorModeChange(button.value)}
+      title={button.label}
+      aria-label={button.label}
+    >
+      {button.icon}
+    </ToolbarButton>
+  ));
 
   return (
     <div className="flex w-max items-center gap-1">

--- a/src/components/Layouts/MainLayout/MainLayout.tsx
+++ b/src/components/Layouts/MainLayout/MainLayout.tsx
@@ -1,25 +1,42 @@
-import { FC, PropsWithChildren } from 'react';
+import { FC, PropsWithChildren, useState } from 'react';
+import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import FoldersPanel from './FoldersPanel/FoldersPanel';
 import FilesPanel from './FilesPanel/FilesPanel';
 import EditorMode from '../../Editor/EditorMode';
+import ToolbarButton from '../../UI/ToolbarButton/ToolbarButton';
 
-const MainLayout: FC<PropsWithChildren> = ({ children }) => (
-  <div className="flex flex-col h-dvh overflow-hidden">
-    <header className="h-9 shrink-0 border-b border-border-color flex items-center justify-end px-4">
-      <EditorMode />
-    </header>
-    <div className="flex flex-1 min-h-0 overflow-hidden">
-      <aside className="w-32 shrink-0 min-h-0 border-r border-border-color">
-        <FoldersPanel />
-      </aside>
-      <aside className="w-64 shrink-0 min-h-0 border-r border-border-color">
-        <FilesPanel />
-      </aside>
-      <main className="flex-1 min-w-0 min-h-0 overflow-auto">
-        {children}
-      </main>
+const MainLayout: FC<PropsWithChildren> = ({ children }) => {
+  const [areSidePanelsCollapsed, setAreSidePanelsCollapsed] = useState(false);
+
+  const sidePanelsVisibilityClassName = areSidePanelsCollapsed ? 'hidden' : '';
+  const sidePanelsToggleLabel = areSidePanelsCollapsed ? 'Show side panels' : 'Hide side panels';
+
+  return (
+    <div className="flex flex-col h-dvh overflow-hidden">
+      <header className="h-9 shrink-0 border-b border-border-color flex items-center justify-between px-4">
+        <ToolbarButton
+          isActive={areSidePanelsCollapsed}
+          onClick={() => setAreSidePanelsCollapsed((previousValue) => !previousValue)}
+          title={sidePanelsToggleLabel}
+          aria-label={sidePanelsToggleLabel}
+        >
+          {areSidePanelsCollapsed ? <PanelLeftOpen className="w-4 h-4" /> : <PanelLeftClose className="w-4 h-4" />}
+        </ToolbarButton>
+        <EditorMode />
+      </header>
+      <div className="flex flex-1 min-h-0 overflow-hidden">
+        <aside className={`w-32 shrink-0 min-h-0 border-r border-border-color ${sidePanelsVisibilityClassName}`}>
+          <FoldersPanel />
+        </aside>
+        <aside className={`w-64 shrink-0 min-h-0 border-r border-border-color ${sidePanelsVisibilityClassName}`}>
+          <FilesPanel />
+        </aside>
+        <main className="flex-1 min-w-0 min-h-0 overflow-auto">
+          {children}
+        </main>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default MainLayout;

--- a/src/components/UI/ToolbarButton/ToolbarButton.tsx
+++ b/src/components/UI/ToolbarButton/ToolbarButton.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react';
+import { IToolbarButtonProps } from './types';
+
+const ToolbarButton: FC<IToolbarButtonProps> = ({
+  children,
+  isActive = false,
+  className = '',
+  disabled,
+  ...rest
+}) => {
+  const stateClassName = isActive ? 'bg-gray-300' : (disabled ? '' : 'hover:bg-gray-200');
+  const interactionClassName = disabled ? 'cursor-not-allowed opacity-50' : 'hover:cursor-pointer';
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      aria-pressed={isActive}
+      className={`${stateClassName} ${interactionClassName} inline-flex items-center p-1 border border-gray-300 text-sm font-medium rounded-md focus:outline-none transition-colors ${className}`}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default ToolbarButton;

--- a/src/components/UI/ToolbarButton/types.ts
+++ b/src/components/UI/ToolbarButton/types.ts
@@ -1,0 +1,5 @@
+import { PropsWithChildren, ButtonHTMLAttributes } from 'react';
+
+export interface IToolbarButtonProps extends PropsWithChildren, ButtonHTMLAttributes<HTMLButtonElement> {
+  isActive?: boolean;
+}


### PR DESCRIPTION
closes #78 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a header toggle to show or hide the folders and files side panels, reclaiming their 384px of space for the editor. The panels hide via CSS rather than unmounting, so an in-progress rename survives a collapse.

**Details**
- Extracts the editor mode buttons’ shared styling into a new `ToolbarButton` UI component used by both the editor mode switcher and the new panel toggle.
- Bumps the app version to `0.8.1`.

<sup>Written for commit fcf1ec7ee54dc308dbca44c7c004f5f35a42fc03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/AlbertArakelyan/Lumark/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

